### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,3 +625,8 @@ You can find detailed changes for each version, including new features, bug fixe
 </p>
 
 <!-- mcp-name: io.github.selvage-lab/selvage -->
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/selvage-lab-selvage).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/selvage-lab-selvage)