### PR TITLE
Add plugin.json to root .claude-plugin/ for marketplace distribution

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "selvage",
+  "version": "0.4.0",
+  "description": "AST-based smart context code review engine for Claude Code",
+  "author": {
+    "name": "Selvage Team",
+    "email": "contact@selvage.me"
+  },
+  "homepage": "https://selvage.me",
+  "repository": "https://github.com/selvage-lab/selvage",
+  "license": "Apache-2.0",
+  "keywords": ["code-review", "ast", "smart-context", "diff-analysis"]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` at the repository root (copies existing file from `plugin/.claude-plugin/`)
- Required by the Claude Code marketplace CI, which validates plugin structure at the repo root level
- The existing `marketplace.json` is already in place — this is the only missing piece for marketplace distribution

No functional changes to the plugin itself.