### PR TITLE
chore+docs: git hooks + branching policy (Sprint 0a Task 2)

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copy main worktree's .claude/settings.json + settings.local.json to the current worktree.
+# Triggered by git worktree add and branch checkouts. Idempotent: skips if file already exists.
+#
+# Why: orca worktrees are created via git worktree add, which does NOT copy untracked files.
+# .claude/settings.json is untracked (likely contains local env / model config), so without
+# this hook, claude sub-agents in worktrees run without project-level Claude settings.
+
+set -euo pipefail
+
+# Find the main worktree (first listed by git worktree list).
+main_dir="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+[ -z "$main_dir" ] && exit 0
+[ "$main_dir" = "$(pwd)" ] && exit 0
+
+mkdir -p .claude
+
+for f in settings.json settings.local.json; do
+  src="$main_dir/.claude/$f"
+  if [ -f "$src" ] && [ ! -f ".claude/$f" ]; then
+    cp "$src" ".claude/$f"
+    echo "[post-checkout] copied .claude/$f from main worktree"
+  fi
+done
+
+exit 0

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -1,0 +1,58 @@
+# Branching Policy
+
+selvage는 3-티어 브랜치 모델을 사용합니다.
+
+## 브랜치 구조
+
+| 브랜치 | 용도 | 권한 |
+|---|---|---|
+| `main` | 프로덕션 릴리스. tag `vX.Y.Z`로 PyPI 정식 배포 | 관리자만 머지 |
+| `develop` | Sprint 통합 지점. TestPyPI 자동 배포 | 관리자 + 핵심 기여자 |
+| `feature/*` | 개별 task 작업. PR → develop | 누구나 생성 |
+
+## 워크플로우
+
+1. **feature 브랜치 생성**
+   ```bash
+   git checkout develop
+   git pull origin develop
+   git checkout -b feature/sprint-N-<topic>
+   ```
+
+2. **작업 + 커밋** (Conventional Commits 준수)
+   - `feat:` 새 기능
+   - `fix:` 버그 수정
+   - `chore:` 설정, 의존성, 문서
+   - `ci:` CI/CD 변경
+   - `docs:` 문서만 변경
+
+3. **PR 생성**: `feature/* → develop`
+   - CI 자동 실행 (pytest, ruff, build)
+   - 모두 통과 시 머지 가능
+
+4. **develop → main PR** (Sprint 종료 시)
+   - 관리자가 squash merge
+   - main push → PyPI 정식 배포 + tag + GitHub Release 자동
+
+## 네이밍 컨벤션
+
+- `feature/sprint-N-<topic>` — Sprint N의 개별 task (예: `feature/sprint-0a-ci-yaml`)
+- `fix/<topic>` — 버그 수정
+- `chore/<topic>` — 설정, 문서, 의존성
+- `release/vX.Y.Z` — 릴리스 준비 (필요 시)
+
+## 보호 규칙 (GitHub Settings)
+
+- `main`: PR required, status checks (CI) required, dismiss stale reviews
+- `develop`: PR required, status checks (CI) required
+- `feature/*`: 자유 (fork-equivalent)
+
+## CI/CD 파이프라인 요약
+
+```
+feature/* → PR → develop    [ci.yml: pytest + ruff + build]
+develop  push              [release.yml: TestPyPI + Docker e2e]
+main     merge             [release.yml: PyPI + tag + GitHub Release]
+```
+
+자세한 사양은 `docs/superpowers/specs/2026-07-17-selvage-master-plan.md`와 `docs/superpowers/plans/2026-07-17-sprint-0a-ci-cd.md` 참조.

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Configure git to use the .githooks/ directory for hooks in this repo.
+# Run once after cloning: ./scripts/setup-git-hooks.sh
+#
+# This enables the post-checkout hook that copies .claude/settings.json and
+# settings.local.json into new git worktrees (including orca-managed worktrees).
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+git config core.hooksPath .githooks
+
+echo "Configured core.hooksPath = .githooks"
+echo "Hooks in .githooks/ will now run on git events."


### PR DESCRIPTION
## Summary
- Add post-checkout git hook copying main worktree's `.claude/settings.json` and `.claude/settings.local.json` to new worktrees. Without this, orca-managed worktrees (and any `git worktree add`) lack project-level Claude env config (e.g. GLM model settings), causing claude sub-agents to run with wrong model.
- Add `scripts/setup-git-hooks.sh` for one-time `core.hooksPath` configuration per clone.
- Add `BRANCHING.md` documenting 3-tier branch model: `main + develop + feature/*`.

## Test plan
- [ ] Run `./scripts/setup-git-hooks.sh` once — verify `git config core.hooksPath` returns `.githooks`
- [ ] Create new git worktree — verify `.claude/settings.json` is auto-copied (post-checkout output: `[post-checkout] copied .claude/settings.json from main worktree`)
- [ ] Verify BRANCHING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)