### PR TITLE
chore: actionlint workflow validation script (Sprint 0a Task 3)

### DIFF
--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Validate all GitHub Actions workflows with actionlint.
+# Run before pushing any workflow change: ./scripts/validate-workflows.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v actionlint >/dev/null 2>&1; then
+  echo "ERROR: actionlint not installed. Run: brew install actionlint" >&2
+  exit 1
+fi
+
+echo "Validating GitHub Actions workflows..."
+# shellcheck disable=SC2046
+if actionlint $(find .github/workflows -name '*.yml' -o -name '*.yaml' 2>/dev/null); then
+  echo "OK: all workflows valid"
+else
+  echo "FAIL: workflow validation failed (see errors above)" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/validate-workflows.sh` — actionlint wrapper to validate all GitHub Actions workflows before push
- Add `.github/workflows/.gitkeep` so the directory exists for the script to find YAML files

## Why
Sprint 0a Task 4-6 will create `.github/workflows/ci.yml` and `release.yml`. Validating them locally before push avoids burning CI minutes on syntax errors. The script fails fast with clear error if actionlint isn't installed.

## Test plan
- [ ] `brew install actionlint` (one-time setup)
- [ ] `./scripts/validate-workflows.sh` exits 0 when workflows are valid (will be testable once Task 4 lands)
- [ ] Script reports `ERROR: actionlint not installed` with exit 1 when actionlint is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)