### PR TITLE
chore: commitizen integration (Sprint 0a Task 7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "twine==6.1.0",
     "wheel==0.43.0",
     "pre-commit==4.2.0",
+    "commitizen==4.1.0",
 ]
 e2e = [
     "testcontainers>=4.0.0",
@@ -88,3 +89,16 @@ Homepage = "https://selvage.me"
 Repository = "https://github.com/selvage-lab/selvage/"
 Documentation = "https://github.com/selvage-lab/selvage/#readme"
 "Bug Tracker" = "https://github.com/selvage-lab/selvage//issues"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.4.1"
+version_files = [
+    "selvage/__version__.py:__version__",
+    "pyproject.toml:version",
+]
+tag_format = "v$version"
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"
+changelog_incremental = true
+annotated_tag = true

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Semantic version bump + CHANGELOG update.
+# Usage: ./scripts/bump-version.sh [major|minor|patch]
+# Default: commitizen이 changelog 기반으로 증분 결정
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+BUMP="${1:-}"
+ARGS=()
+if [ -n "$BUMP" ]; then
+  ARGS+=("--increment" "$BUMP")
+fi
+
+# commitizen이 버전 결정 + CHANGELOG 갱신 + 커밋 + 태그
+cz bump "${ARGS[@]}"
+
+# push
+git push --follow-tags origin "$(git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION
## Summary
- Add `commitizen==4.1.0` to `[project.optional-dependencies] dev`
- Add `[tool.commitizen]` config block to `pyproject.toml` (conventional commits, auto-changelog, tag format `v$version`, version syncs with `selvage/__version__.py`)
- Add `scripts/bump-version.sh` wrapper for `cz bump` + push

## Why
Sprint 0a plans to release v0.4.2 (and beyond). Commitizen automates: (1) determining next version from conventional commits, (2) updating CHANGELOG.md, (3) tagging. Manual version bumps are error-prone.

## Test plan
- [ ] `pip install -e ".[dev]"` succeeds with commitizen
- [ ] `cz version --dry-run --patch` prints the next version without committing
- [ ] `./scripts/bump-version.sh` (when ready to release) creates the commit, tag, and pushes both

🤖 Generated with [Claude Code](https://claude.com/claude-code)