### PR TITLE
feat(eval): Pydantic data models for ReviewRun, DiffSource, GoldenFixture (Sprint 0c Phase B)

### DIFF
--- a/eval/schemas/golden.v1.json
+++ b/eval/schemas/golden.v1.json
@@ -1,0 +1,299 @@
+{
+  "$defs": {
+    "DiffSource": {
+      "additionalProperties": false,
+      "description": "Synthetic inline diff or metadata-only external OSS diff.\n\nExternal source code is never stored in a fixture. It is resolved at runtime\nfrom the repository metadata after its license has passed the allowlist.",
+      "properties": {
+        "commit_sha": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Commit Sha"
+        },
+        "diff_range": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Diff Range"
+        },
+        "inline_patch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inline Patch"
+        },
+        "kind": {
+          "enum": [
+            "synthetic",
+            "external"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "license_attribution": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "License Attribution"
+        },
+        "license_kind": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "License Kind"
+        },
+        "repo_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repo Url"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "title": "DiffSource",
+      "type": "object"
+    },
+    "ExpectedFinding": {
+      "additionalProperties": false,
+      "description": "A positively labelled finding in a golden fixture.",
+      "properties": {
+        "aliases": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Aliases",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "categories": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Categories",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "locations": {
+          "items": {
+            "$ref": "#/$defs/Location"
+          },
+          "title": "Locations",
+          "type": "array"
+        },
+        "required": {
+          "default": true,
+          "title": "Required",
+          "type": "boolean"
+        },
+        "severity": {
+          "title": "Severity",
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "id",
+        "locations",
+        "categories",
+        "severity"
+      ],
+      "title": "ExpectedFinding",
+      "type": "object"
+    },
+    "Location": {
+      "additionalProperties": false,
+      "description": "An expected finding location or symbol.",
+      "properties": {
+        "end_line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "End Line"
+        },
+        "file": {
+          "title": "File",
+          "type": "string"
+        },
+        "start_line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Line"
+        },
+        "symbol": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Symbol"
+        }
+      },
+      "required": [
+        "file"
+      ],
+      "title": "Location",
+      "type": "object"
+    },
+    "NegativeExpectation": {
+      "additionalProperties": false,
+      "description": "A finding category that must not be emitted.",
+      "properties": {
+        "forbidden_categories": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Forbidden Categories",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Location"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "NegativeExpectation",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Versioned deterministic ground truth for a diff.",
+  "properties": {
+    "case_id": {
+      "title": "Case Id",
+      "type": "string"
+    },
+    "diff_sha256": {
+      "title": "Diff Sha256",
+      "type": "string"
+    },
+    "diff_source": {
+      "$ref": "#/$defs/DiffSource"
+    },
+    "expected": {
+      "items": {
+        "$ref": "#/$defs/ExpectedFinding"
+      },
+      "title": "Expected",
+      "type": "array"
+    },
+    "negatives": {
+      "items": {
+        "$ref": "#/$defs/NegativeExpectation"
+      },
+      "title": "Negatives",
+      "type": "array"
+    },
+    "provenance": {
+      "additionalProperties": true,
+      "title": "Provenance",
+      "type": "object"
+    },
+    "schema_version": {
+      "default": "golden/v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "stack": {
+      "title": "Stack",
+      "type": "string"
+    },
+    "thresholds": {
+      "additionalProperties": {
+        "type": "number"
+      },
+      "title": "Thresholds",
+      "type": "object"
+    }
+  },
+  "required": [
+    "case_id",
+    "diff_source",
+    "diff_sha256",
+    "stack",
+    "expected",
+    "thresholds",
+    "provenance"
+  ],
+  "title": "GoldenFixture",
+  "type": "object"
+}

--- a/eval/schemas/review-run.v1.json
+++ b/eval/schemas/review-run.v1.json
@@ -1,0 +1,402 @@
+{
+  "$defs": {
+    "Budget": {
+      "additionalProperties": false,
+      "description": "Resource usage for a review run.",
+      "properties": {
+        "cost_usd": {
+          "default": 0,
+          "title": "Cost Usd",
+          "type": "number"
+        },
+        "input_tokens": {
+          "default": 0,
+          "title": "Input Tokens",
+          "type": "integer"
+        },
+        "max_context_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Context Tokens"
+        },
+        "output_tokens": {
+          "default": 0,
+          "title": "Output Tokens",
+          "type": "integer"
+        },
+        "wall_time_ms": {
+          "default": 0,
+          "title": "Wall Time Ms",
+          "type": "integer"
+        }
+      },
+      "title": "Budget",
+      "type": "object"
+    },
+    "ContextChunk": {
+      "additionalProperties": false,
+      "description": "A context fragment made available to the reviewer.",
+      "properties": {
+        "chunk_id": {
+          "title": "Chunk Id",
+          "type": "string"
+        },
+        "content_sha256": {
+          "title": "Content Sha256",
+          "type": "string"
+        },
+        "end_line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "End Line"
+        },
+        "file": {
+          "title": "File",
+          "type": "string"
+        },
+        "start_line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Line"
+        },
+        "strategy": {
+          "title": "Strategy",
+          "type": "string"
+        },
+        "text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Text"
+        }
+      },
+      "required": [
+        "chunk_id",
+        "file",
+        "content_sha256",
+        "strategy"
+      ],
+      "title": "ContextChunk",
+      "type": "object"
+    },
+    "DiffSnapshot": {
+      "additionalProperties": false,
+      "description": "Immutable diff material captured for a review run.",
+      "properties": {
+        "base_sha": {
+          "title": "Base Sha",
+          "type": "string"
+        },
+        "files": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Files",
+          "type": "array"
+        },
+        "head_sha": {
+          "title": "Head Sha",
+          "type": "string"
+        },
+        "patch": {
+          "title": "Patch",
+          "type": "string"
+        },
+        "sha256": {
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "base_sha",
+        "head_sha",
+        "patch",
+        "sha256",
+        "files"
+      ],
+      "title": "DiffSnapshot",
+      "type": "object"
+    },
+    "Finding": {
+      "additionalProperties": false,
+      "description": "Normalized issue emitted by a review run.",
+      "properties": {
+        "category": {
+          "title": "Category",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "end_line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "End Line"
+        },
+        "evidence": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence",
+          "type": "array"
+        },
+        "file": {
+          "title": "File",
+          "type": "string"
+        },
+        "finding_id": {
+          "title": "Finding Id",
+          "type": "string"
+        },
+        "severity": {
+          "title": "Severity",
+          "type": "string"
+        },
+        "start_line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Line"
+        },
+        "target_symbol": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Target Symbol"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "finding_id",
+        "file",
+        "category",
+        "severity",
+        "title",
+        "description"
+      ],
+      "title": "Finding",
+      "type": "object"
+    },
+    "ToolCall": {
+      "additionalProperties": false,
+      "description": "A tool invocation observed during a review.",
+      "properties": {
+        "arguments": {
+          "additionalProperties": true,
+          "title": "Arguments",
+          "type": "object"
+        },
+        "call_id": {
+          "title": "Call Id",
+          "type": "string"
+        },
+        "duration_ms": {
+          "title": "Duration Ms",
+          "type": "integer"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "result_sha256": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Result Sha256"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "call_id",
+        "name",
+        "arguments",
+        "status",
+        "duration_ms"
+      ],
+      "title": "ToolCall",
+      "type": "object"
+    },
+    "VersionRef": {
+      "additionalProperties": false,
+      "description": "Reference to a versioned review component.",
+      "properties": {
+        "digest": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Digest"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "version": {
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "title": "VersionRef",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Replayable manifest for one code review execution.",
+  "properties": {
+    "budgets": {
+      "$ref": "#/$defs/Budget"
+    },
+    "context_chunks": {
+      "items": {
+        "$ref": "#/$defs/ContextChunk"
+      },
+      "title": "Context Chunks",
+      "type": "array"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "diff": {
+      "$ref": "#/$defs/DiffSnapshot"
+    },
+    "error": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Error"
+    },
+    "findings": {
+      "items": {
+        "$ref": "#/$defs/Finding"
+      },
+      "title": "Findings",
+      "type": "array"
+    },
+    "model": {
+      "$ref": "#/$defs/VersionRef"
+    },
+    "prompt": {
+      "$ref": "#/$defs/VersionRef"
+    },
+    "run_id": {
+      "title": "Run Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "default": "review-run/v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "skills": {
+      "items": {
+        "$ref": "#/$defs/VersionRef"
+      },
+      "title": "Skills",
+      "type": "array"
+    },
+    "source": {
+      "additionalProperties": true,
+      "title": "Source",
+      "type": "object"
+    },
+    "status": {
+      "title": "Status",
+      "type": "string"
+    },
+    "tool_calls": {
+      "items": {
+        "$ref": "#/$defs/ToolCall"
+      },
+      "title": "Tool Calls",
+      "type": "array"
+    }
+  },
+  "required": [
+    "run_id",
+    "created_at",
+    "source",
+    "diff",
+    "model",
+    "prompt",
+    "budgets",
+    "status"
+  ],
+  "title": "ReviewRun",
+  "type": "object"
+}

--- a/selvage/src/eval/__init__.py
+++ b/selvage/src/eval/__init__.py
@@ -1,0 +1,35 @@
+"""Deterministic evaluation contracts for Selvage."""
+
+from selvage.src.eval.models import (
+    Budget,
+    ContextChunk,
+    DiffSnapshot,
+    DiffSource,
+    EvalReport,
+    ExpectedFinding,
+    Finding,
+    GoldenFixture,
+    Location,
+    MetricResult,
+    NegativeExpectation,
+    ReviewRun,
+    ToolCall,
+    VersionRef,
+)
+
+__all__ = [
+    "Budget",
+    "ContextChunk",
+    "DiffSnapshot",
+    "DiffSource",
+    "EvalReport",
+    "ExpectedFinding",
+    "Finding",
+    "GoldenFixture",
+    "Location",
+    "MetricResult",
+    "NegativeExpectation",
+    "ReviewRun",
+    "ToolCall",
+    "VersionRef",
+]

--- a/selvage/src/eval/models.py
+++ b/selvage/src/eval/models.py
@@ -1,0 +1,258 @@
+"""Versioned Pydantic contracts for deterministic evaluation."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class VersionRef(BaseModel):
+    """Reference to a versioned review component."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    version: str
+    digest: str | None = None
+
+
+class DiffSnapshot(BaseModel):
+    """Immutable diff material captured for a review run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    base_sha: str
+    head_sha: str
+    patch: str
+    sha256: str
+    files: list[str]
+
+
+class ContextChunk(BaseModel):
+    """A context fragment made available to the reviewer."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chunk_id: str
+    file: str
+    start_line: int | None = None
+    end_line: int | None = None
+    content_sha256: str
+    text: str | None = None
+    strategy: str
+
+
+class ToolCall(BaseModel):
+    """A tool invocation observed during a review."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    call_id: str
+    name: str
+    arguments: dict
+    result_sha256: str | None = None
+    status: str
+    duration_ms: int
+
+
+class Budget(BaseModel):
+    """Resource usage for a review run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    max_context_tokens: int | None = None
+    cost_usd: float = 0
+    wall_time_ms: int = 0
+
+
+class Finding(BaseModel):
+    """Normalized issue emitted by a review run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    finding_id: str
+    file: str
+    start_line: int | None = None
+    end_line: int | None = None
+    category: str
+    severity: str
+    title: str
+    description: str
+    target_symbol: str | None = None
+    evidence: list[str] = Field(default_factory=list)
+
+
+class ReviewRun(BaseModel):
+    """Replayable manifest for one code review execution."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "review-run/v1"
+    run_id: str
+    created_at: datetime
+    source: dict
+    diff: DiffSnapshot
+    model: VersionRef
+    prompt: VersionRef
+    skills: list[VersionRef] = Field(default_factory=list)
+    context_chunks: list[ContextChunk] = Field(default_factory=list)
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    budgets: Budget
+    findings: list[Finding] = Field(default_factory=list)
+    status: str
+    error: str | None = None
+
+
+ALLOWED_EXTERNAL_LICENSES = frozenset(
+    {
+        "MIT",
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "ISC",
+        "MPL-2.0",
+    }
+)
+
+
+class DiffSource(BaseModel):
+    """Synthetic inline diff or metadata-only external OSS diff.
+
+    External source code is never stored in a fixture. It is resolved at runtime
+    from the repository metadata after its license has passed the allowlist.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["synthetic", "external"]
+    inline_patch: str | None = None
+    repo_url: str | None = None
+    commit_sha: str | None = None
+    diff_range: str | None = None
+    license_attribution: str | None = None
+    license_kind: str | None = None
+
+    @field_validator("license_kind")
+    @classmethod
+    def validate_license_kind(cls, value: str | None) -> str | None:
+        """Accept only the explicitly approved OSS license identifiers."""
+        if value is not None and value not in ALLOWED_EXTERNAL_LICENSES:
+            allowed = ", ".join(sorted(ALLOWED_EXTERNAL_LICENSES))
+            raise ValueError(f"license_kind must be one of: {allowed}")
+        return value
+
+    @model_validator(mode="after")
+    def validate_source_shape(self) -> "DiffSource":
+        """Keep synthetic code and external repository metadata disjoint."""
+        external_fields = (
+            "repo_url",
+            "commit_sha",
+            "diff_range",
+            "license_attribution",
+            "license_kind",
+        )
+        if self.kind == "synthetic":
+            if self.inline_patch is None:
+                raise ValueError("inline_patch is required for synthetic sources")
+            populated = [
+                name for name in external_fields if getattr(self, name) is not None
+            ]
+            if populated:
+                names = ", ".join(populated)
+                raise ValueError(f"synthetic sources forbid external fields: {names}")
+            return self
+
+        required = [name for name in external_fields if getattr(self, name) is None]
+        if required:
+            names = ", ".join(required)
+            raise ValueError(f"external sources require fields: {names}")
+        if self.inline_patch is not None:
+            raise ValueError("inline_patch is forbidden for external sources")
+        return self
+
+
+class Location(BaseModel):
+    """An expected finding location or symbol."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    file: str
+    start_line: int | None = None
+    end_line: int | None = None
+    symbol: str | None = None
+
+
+class ExpectedFinding(BaseModel):
+    """A positively labelled finding in a golden fixture."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    locations: list[Location]
+    categories: set[str]
+    severity: str
+    aliases: set[str] = Field(default_factory=set)
+    required: bool = True
+    tags: set[str] = Field(default_factory=set)
+
+
+class NegativeExpectation(BaseModel):
+    """A finding category that must not be emitted."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    location: Location | None = None
+    forbidden_categories: set[str] = Field(default_factory=set)
+
+
+class GoldenFixture(BaseModel):
+    """Versioned deterministic ground truth for a diff."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "golden/v1"
+    case_id: str
+    diff_source: DiffSource
+    diff_sha256: str
+    stack: str
+    expected: list[ExpectedFinding]
+    negatives: list[NegativeExpectation] = Field(default_factory=list)
+    thresholds: dict[str, float]
+    provenance: dict
+
+
+class MetricResult(BaseModel):
+    """One metric with an explicit denominator and visible N/A state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: float | None
+    numerator: float
+    denominator: float
+    na_reason: str | None = None
+
+    @model_validator(mode="after")
+    def validate_na_state(self) -> "MetricResult":
+        """Require an explanation whenever a metric is not applicable."""
+        if self.value is None and self.na_reason is None:
+            raise ValueError("na_reason is required when value is N/A")
+        if self.value is not None and self.na_reason is not None:
+            raise ValueError("na_reason is only valid when value is N/A")
+        return self
+
+
+class EvalReport(BaseModel):
+    """Evaluation results containing both micro and macro aggregates."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "eval-report/v1"
+    report_id: str
+    created_at: datetime
+    micro: dict[str, MetricResult]
+    macro: dict[str, MetricResult]
+    cases: dict[str, dict[str, MetricResult]] = Field(default_factory=dict)
+    metadata: dict = Field(default_factory=dict)

--- a/selvage/src/eval/schema_export.py
+++ b/selvage/src/eval/schema_export.py
@@ -1,0 +1,49 @@
+"""Export stable JSON Schema contracts for evaluation payloads."""
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from selvage.src.eval.models import GoldenFixture, ReviewRun
+
+
+def schema_documents() -> dict[str, dict]:
+    """Return each public wire contract keyed by its canonical filename."""
+    return {
+        "review-run.v1.json": ReviewRun.model_json_schema(),
+        "golden.v1.json": GoldenFixture.model_json_schema(),
+    }
+
+
+def export_schemas(output: Path) -> list[Path]:
+    """Write deterministic JSON Schema documents into *output*."""
+    output.mkdir(parents=True, exist_ok=True)
+    written = []
+    for filename, schema in schema_documents().items():
+        destination = output / filename
+        destination.write_text(
+            json.dumps(schema, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        written.append(destination)
+    return written
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the JSON Schema export CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("eval/schemas"),
+        help="directory for generated schema files (default: eval/schemas)",
+    )
+    args = parser.parse_args(argv)
+    for path in export_schemas(args.output):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/eval/__init__.py
+++ b/tests/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the deterministic evaluation data contracts."""

--- a/tests/eval/test_diff_source.py
+++ b/tests/eval/test_diff_source.py
@@ -1,0 +1,98 @@
+"""Validation tests for licensed synthetic and external diff sources."""
+
+import pytest
+from pydantic import ValidationError
+
+from selvage.src.eval.models import DiffSource
+
+
+def test_synthetic_requires_inline_patch() -> None:
+    with pytest.raises(ValidationError, match="inline_patch"):
+        DiffSource(kind="synthetic")
+
+
+@pytest.mark.parametrize("forbidden", ["repo_url", "commit_sha"])
+def test_synthetic_forbids_external_repository_fields(forbidden: str) -> None:
+    payload = {"kind": "synthetic", "inline_patch": "diff --git a/a b/a\n"}
+    payload[forbidden] = (
+        "https://example.com/repo.git" if forbidden == "repo_url" else "abc"
+    )
+
+    with pytest.raises(ValidationError, match=forbidden):
+        DiffSource.model_validate(payload)
+
+
+def test_external_requires_all_attribution_fields() -> None:
+    required = {
+        "repo_url": "https://example.com/repo.git",
+        "commit_sha": "a" * 40,
+        "diff_range": "HEAD^..HEAD",
+        "license_attribution": "Copyright Example Authors, MIT License",
+        "license_kind": "MIT",
+    }
+    for missing in required:
+        payload = {"kind": "external", **required}
+        del payload[missing]
+        with pytest.raises(ValidationError, match=missing):
+            DiffSource.model_validate(payload)
+
+
+def test_external_forbids_inline_patch() -> None:
+    with pytest.raises(ValidationError, match="inline_patch"):
+        DiffSource(
+            kind="external",
+            inline_patch="external code must not be stored",
+            repo_url="https://example.com/repo.git",
+            commit_sha="a" * 40,
+            diff_range="HEAD^..HEAD",
+            license_attribution="Copyright Example Authors",
+            license_kind="MIT",
+        )
+
+
+@pytest.mark.parametrize(
+    "license_kind",
+    [
+        "MIT",
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "ISC",
+        "MPL-2.0",
+    ],
+)
+def test_external_accepts_whitelisted_licenses(license_kind: str) -> None:
+    source = DiffSource(
+        kind="external",
+        repo_url="https://example.com/repo.git",
+        commit_sha="a" * 40,
+        diff_range="HEAD^..HEAD",
+        license_attribution="Copyright Example Authors",
+        license_kind=license_kind,
+    )
+
+    assert source.license_kind == license_kind
+
+
+@pytest.mark.parametrize(
+    "license_kind", ["GPL-3.0", "LGPL-3.0", "AGPL-3.0", "Commercial"]
+)
+def test_external_rejects_non_whitelisted_licenses(license_kind: str) -> None:
+    with pytest.raises(ValidationError, match="license_kind"):
+        DiffSource(
+            kind="external",
+            repo_url="https://example.com/repo.git",
+            commit_sha="a" * 40,
+            diff_range="HEAD^..HEAD",
+            license_attribution="Copyright Example Authors",
+            license_kind=license_kind,
+        )
+
+
+def test_diff_source_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError, match="mirror_url"):
+        DiffSource(
+            kind="synthetic",
+            inline_patch="diff --git a/a b/a\n",
+            mirror_url="https://example.com/mirror.git",
+        )

--- a/tests/eval/test_models.py
+++ b/tests/eval/test_models.py
@@ -1,0 +1,205 @@
+"""Contract tests for review-run/v1 and golden/v1 models."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from selvage.src.eval.models import (
+    Budget,
+    ContextChunk,
+    DiffSnapshot,
+    EvalReport,
+    ExpectedFinding,
+    Finding,
+    GoldenFixture,
+    Location,
+    MetricResult,
+    NegativeExpectation,
+    ReviewRun,
+    ToolCall,
+    VersionRef,
+)
+from selvage.src.eval.schema_export import schema_documents
+
+
+def _instances() -> list[BaseModel]:
+    version = VersionRef(name="selvage", version="v4", digest="sha256:prompt")
+    diff = DiffSnapshot(
+        base_sha="a" * 40,
+        head_sha="b" * 40,
+        patch="diff --git a/app.py b/app.py\n",
+        sha256="c" * 64,
+        files=["app.py"],
+    )
+    chunk = ContextChunk(
+        chunk_id="chunk-1",
+        file="app.py",
+        start_line=1,
+        end_line=4,
+        content_sha256="d" * 64,
+        text="def f():\n    pass\n",
+        strategy="smart",
+    )
+    tool_call = ToolCall(
+        call_id="call-1",
+        name="read_file",
+        arguments={"path": "app.py"},
+        result_sha256="e" * 64,
+        status="success",
+        duration_ms=5,
+    )
+    budget = Budget(input_tokens=10, output_tokens=20, wall_time_ms=30)
+    finding = Finding(
+        finding_id="finding-1",
+        file="app.py",
+        start_line=2,
+        end_line=2,
+        category="correctness",
+        severity="error",
+        title="Incorrect return",
+        description="The function returns the wrong value.",
+        evidence=["return False"],
+    )
+    run = ReviewRun(
+        run_id="run-1",
+        created_at=datetime(2026, 7, 18, tzinfo=timezone.utc),
+        source={"repo": "selvage", "commit": "b" * 40},
+        diff=diff,
+        model=VersionRef(name="provider/model", version="2026-07-18"),
+        prompt=version,
+        skills=[VersionRef(name="review", version="1")],
+        context_chunks=[chunk],
+        tool_calls=[tool_call],
+        budgets=budget,
+        findings=[finding],
+        status="success",
+    )
+    location = Location(file="app.py", start_line=2, end_line=2, symbol="f")
+    expected = ExpectedFinding(
+        id="expected-1",
+        locations=[location],
+        categories={"correctness"},
+        severity="error",
+        aliases={"logic"},
+        tags={"caller"},
+    )
+    negative = NegativeExpectation(
+        id="negative-1",
+        location=location,
+        forbidden_categories={"style"},
+    )
+    fixture = GoldenFixture(
+        case_id="python-wrong-return",
+        diff_source={"kind": "synthetic", "inline_patch": diff.patch},
+        diff_sha256=diff.sha256,
+        stack="python",
+        expected=[expected],
+        negatives=[negative],
+        thresholds={"precision": 0.8, "recall": 0.8},
+        provenance={"source_sha": "b" * 40, "labelers": ["alice", "bob"]},
+    )
+    report = EvalReport(
+        report_id="report-1",
+        created_at=datetime(2026, 7, 18, tzinfo=timezone.utc),
+        micro={
+            "precision": MetricResult(value=1.0, numerator=1, denominator=1),
+            "false_positive_rate": MetricResult(
+                value=None,
+                numerator=0,
+                denominator=0,
+                na_reason="no negative expectations",
+            ),
+        },
+        macro={"precision": MetricResult(value=1.0, numerator=1, denominator=1)},
+    )
+    return [
+        version,
+        diff,
+        chunk,
+        tool_call,
+        budget,
+        finding,
+        run,
+        location,
+        expected,
+        negative,
+        fixture,
+        report.micro["precision"],
+        report,
+    ]
+
+
+@pytest.mark.parametrize("instance", _instances())
+def test_models_round_trip(instance: BaseModel) -> None:
+    payload = json.dumps(instance.model_dump(mode="json"))
+
+    restored = type(instance).model_validate_json(payload)
+
+    assert restored == instance
+
+
+@pytest.mark.parametrize("instance", _instances())
+def test_all_models_forbid_extra_fields(instance: BaseModel) -> None:
+    payload = instance.model_dump(mode="json")
+    payload["unexpected"] = True
+
+    with pytest.raises(ValidationError, match="unexpected"):
+        type(instance).model_validate(payload)
+
+
+def test_schema_version_defaults() -> None:
+    run = next(item for item in _instances() if isinstance(item, ReviewRun))
+    fixture = next(item for item in _instances() if isinstance(item, GoldenFixture))
+    report = next(item for item in _instances() if isinstance(item, EvalReport))
+
+    assert run.schema_version == "review-run/v1"
+    assert fixture.schema_version == "golden/v1"
+    assert report.schema_version == "eval-report/v1"
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (VersionRef, {"name": "prompt"}),
+        (
+            DiffSnapshot,
+            {"base_sha": "a", "head_sha": "b", "patch": "", "sha256": "c"},
+        ),
+        (ReviewRun, {"run_id": "run-1"}),
+        (Location, {}),
+        (ExpectedFinding, {"id": "finding-1"}),
+        (GoldenFixture, {"case_id": "case-1"}),
+        (EvalReport, {"report_id": "report-1"}),
+    ],
+)
+def test_required_fields(model: type[BaseModel], payload: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_metric_result_exposes_zero_denominator_as_na() -> None:
+    result = MetricResult(
+        value=None,
+        numerator=0,
+        denominator=0,
+        na_reason="no negative expectations",
+    )
+
+    assert result.value is None
+    assert result.na_reason == "no negative expectations"
+
+
+def test_metric_result_rejects_hidden_na_state() -> None:
+    with pytest.raises(ValidationError):
+        MetricResult(value=None, numerator=0, denominator=0)
+
+
+def test_exported_schemas_match_committed_contracts() -> None:
+    schema_dir = Path(__file__).parents[2] / "eval" / "schemas"
+
+    for filename, schema in schema_documents().items():
+        committed = json.loads((schema_dir / filename).read_text(encoding="utf-8"))
+        assert committed == schema


### PR DESCRIPTION
## Summary
Sprint 0c Phase B — 자체 경량 eval 인프라의 데이터 모델과 JSON Schema contract 구축.

- `selvage/src/eval/models.py` — ReviewRun, DiffSource, GoldenFixture, Finding, ExpectedFinding, NegativeExpectation, Location, VersionRef, DiffSnapshot, ContextChunk, ToolCall, Budget, EvalReport (Pydantic v2, extra='forbid')
- `selvage/src/eval/schema_export.py` — JSON Schema export CLI
- `eval/schemas/review-run.v1.json`, `golden.v1.json` — versioned schema contracts
- `tests/eval/test_models.py` — round-trip, extra forbid, schema_version 기본값
- `tests/eval/test_diff_source.py` — synthetic/external validation, **라이센스 화이트리스트** (MIT/Apache/BSD/ISC/MPL OK, GPL/AGPL 거부)

## Why
Sprint 1 (AST V2)과 Sprint 2 (Verified Review)의 metric(caller recall, FP rate)을 측정하려면 eval 인프라가 선행. DeepEval을 버리고 자체 경량 접근 — 마스터 플랜 v1.2 ADR-007에 따라.

## 라이센스 정책 (DiffSource)
- synthetic: selvage 팀이 직접 작성한 inline 패치 (Apache 2.0)
- external: 외부 OSS repo의 diff를 runtime clone, **코드 저장 X** (메타데이터만: repo_url, commit_sha, diff_range, license_attribution, license_kind)
- license_kind 화이트리스트: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0
- GPL/LGPL/AGPL/상용은 fixture validator가 거부

## Test plan
- [ ] `pytest tests/eval/ -v` passes (신규 2개 파일)
- [ ] `pytest tests/ --timeout=300` 기존 823+ 테스트 회귀 없음
- [ ] `python -m selvage.src.eval.schema_export --output eval/schemas/` JSON Schema 재생성 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)