### PR TITLE
docs: master plan v1.3 + Sprint 0a/0c plans + 2026-07 research

### DIFF
--- a/docs/research/external/2026-07-17-ast-context-research.md
+++ b/docs/research/external/2026-07-17-ast-context-research.md
@@ -1,0 +1,101 @@
+# Selvage AST 기반 Smart Context 고도화 딥리서치
+
+> 조사일: 2026-07-17 · 대상: Python CLI, Apache-2.0, 1인 메인테이너 관점
+
+## 1. 결론 요약
+
+Selvage가 다음에 만들어야 할 것은 “더 큰 AST 블록”이 아니라 **변경 심볼을 기점으로 한 작은 repository context graph**다. 현재 `ContextExtractor`는 변경 라인을 포함하는 같은 파일의 최소 함수·클래스와 모든 import를 반환한다. 실제 AST 지원은 Python, JavaScript, TypeScript, Java, Kotlin이며 Go/Rust 등은 `FALLBACK_CONTEXT`의 정규식 import와 변경부 ±5줄에 머문다. 따라서 동일 이름의 다른 정의를 구별하지 못하고, 다른 파일의 caller/definition/contract를 찾지 못하며, 보안·정책 위반도 LLM이 매번 재판단한다.
+
+가장 현실적인 진화 순서는 다음과 같다.
+
+1. 기존 Python tree-sitter 위에 공식 `tags.scm` 계열 query를 얹어 symbol definition/reference/call을 정규화한다.
+2. 파일별 결과를 SQLite에 캐시하고 import/call edge를 구성한다.
+3. diff의 변경 심볼에서 caller/callee를 1~2 hop 탐색해 토큰 예산으로 자른다.
+4. Aider식 중요도 랭킹으로 “무엇을 넣을지” 결정한다.
+5. ast-grep 규칙은 결정적 pre-review로 실행해 확정 finding은 LLM 추론에서 제외하거나 증거로 전달한다.
+
+SCIP·CodeQL은 정확도의 상한을 보여주는 **선택적 외부 index adapter**, stack-graphs와 Greptile은 설계 참고가 적절하다. 벡터 RAG는 자연어 의도·유사 구현 검색에는 좋지만 caller chain의 진실 공급원으로 쓰면 안 된다.
+
+## 2. 현재 SMART_CONTEXT의 한계
+
+| 한계 | 실패 시나리오 | 필요한 보완 |
+|---|---|---|
+| 파일 내부·라인 중심 | `service.py:update_user()` 반환형 변경을 `api.py`와 테스트의 caller가 계속 옛 계약으로 사용 | symbol index + cross-file reverse call edge |
+| 문법 블록만 인지 | 서로 다른 모듈에 `parse()`가 여럿이면 단순 이름 참조가 어느 정의인지 불명확 | import alias, scope, qualified name을 고려한 name resolution |
+| 모든 import를 무조건 첨부 | 큰 파일에서 실제 변경과 무관한 import가 토큰을 소비 | 변경 심볼이 참조하는 dependency만 선택 |
+| 언어별 node type 하드코딩 | grammar 업데이트·새 언어마다 Python 코드를 수정 | 버전 고정된 query pack(`tags.scm`)과 fixture test |
+| 규칙 탐지 없음 | `subprocess.run(..., shell=True)`, 문자열 SQL, 검증 누락을 LLM이 비결정적으로 판단 | ast-grep/Semgrep의 deterministic rule gate |
+| freshness/ranking 없음 | 매 리뷰 전체 repo를 훑거나, 발견한 관련 심볼을 모두 넣어 prompt 팽창 | mtime/content-hash incremental cache + graph rank/token budget |
+
+## 3. OSS·프레임워크 비교
+
+통합 복잡도는 Selvage에 실제 기능을 넣는 비용(낮음/중간/높음/매우 높음)이다.
+
+| 접근법 | 정의와 작동 방식 | Selvage 적용·가져올 가치 | 라이선스·의존성 | 복잡도 |
+|---|---|---|---|---|
+| **Aider repo map** | tree-sitter query로 파일별 definition/reference tag를 만들고, reference→definition 파일 graph에 가중 PageRank를 수행한다. 채팅 파일·언급 식별자에 personalization을 주고, 상위 정의의 signature/핵심 line을 토큰 예산 안에서 렌더링·캐시한다. [공식 설명](https://aider.chat/2023/10/22/repomap.html), [구현](https://github.com/Aider-AI/aider/blob/main/aider/repomap.py) | `changed symbol`을 personalization seed로 삼아 repo outline과 관련 심볼을 압축한다. 단, 같은 이름을 연결하는 heuristic이므로 정확한 caller graph가 아니라 **ranking layer**로 사용한다. | Apache-2.0. Python, tree-sitter/`grep-ast`, NetworkX, disk cache 계열. 코드를 통째로 가져오기보다 알고리즘 재구현 권장. | **중간** |
+| **SCIP** | LSIF 후속인 언어 중립 Protobuf index. 문서별 occurrence(range, symbol, role)와 symbol information을 저장하여 go-to-definition, references, implementations를 compiler-accurate하게 제공한다. [schema/도구](https://github.com/sourcegraph/scip), [index 구조](https://sourcegraph.com/docs/code-navigation/writing-an-indexer) | `index.scip` consumer를 선택 기능으로 두면 TS/JS, Java/Kotlin, Python, Go, Rust 등의 정확한 definition/reference를 공통 모델로 흡수할 수 있다. caller는 reference occurrence를 AST의 call site·enclosing symbol과 결합해 역조회한다. 빌드·의존성 해석이 필요한 언어별 indexer 설치/실행은 사용자 책임으로 둔다. | Protocol/주요 indexer Apache-2.0, Protobuf와 외부 언어별 indexer 필요. Python 공식 rich binding은 없으므로 generated protobuf 또는 `scip` JSON/snapshot adapter 필요. | **높음** |
+| **tree-sitter-stack-graphs** | 언어별 name-binding 규칙을 DSL로 기술하고 reference/definition, scope push/pop graph의 유효 경로를 찾는다. 파일별 partial path를 미리 만들고 query 때 stitch해 shadowing·import를 증분 해석한다. [원리](https://github.blog/open-source/introducing-stack-graphs/), [저장소](https://github.com/github/stack-graphs) | build 없이 Python import/alias/shadowing을 푸는 아이디어는 훌륭하다. 그러나 call graph가 아니라 name resolution 기반이며 각 언어 규칙을 유지해야 한다. **Python 한정 실험 외에는 패스**하고, “파일별 fact + query-time stitch” 설계만 차용한다. | MIT OR Apache-2.0. Rust crate/CLI, tree-sitter, SQLite 기능. 저장소가 GitHub의 지원·업데이트 종료 상태임을 명시한다. | **매우 높음** |
+| **ast-grep** | tree-sitter AST에 실제 코드처럼 쓴 pattern과 `$META` wildcard를 구조적으로 매칭한다. YAML rule, relational/composite 조건, test, JSON 결과를 지원한다. [프로젝트](https://github.com/ast-grep/ast-grep), [JSON/단일 rule 실행](https://ast-grep.github.io/guide/tooling-overview.html) | 보안·정책 pattern을 diff 파일/변경 range에 결정적으로 적용한다. 예: shell 실행, raw SQL, 위험 API를 JSON finding으로 받아 `RULE_CONTEXT`로 직접 보고하고 LLM에는 “확정 사실+주변 함수”만 준다. LLM 토큰·재현성·false narrative를 줄인다. name resolution/caller chain 도구는 아니다. | MIT. Rust 구현이지만 `ast-grep-cli` pip wheel/standalone CLI가 있어 Python에서는 `subprocess`+JSON로 격리 가능; source build 불필요. | **낮음~중간** |
+| **Semgrep CE** | 코드 유사 YAML pattern, metavariable, constant propagation, intraprocedural dataflow/taint로 다언어 정적 분석을 수행한다. 동일 입력에 deterministic·offline인 것이 원칙이다. [CE 원칙](https://semgrep.dev/docs/contributing/semgrep-philosophy), [규칙 예시](https://semgrep.dev/docs/writing-rules/rule-ideas) | 검증된 보안 규칙과 taint가 ast-grep보다 강하다. 선택적 `selvage review --semgrep`에서 SARIF/JSON finding을 context에 합치는 방식이 현실적이다. 다만 CE는 파일 경계를 넘지 않으므로 caller chain 해법은 아니며, 기본 설치 크기·실행시간도 더 크다. | Engine LGPL-2.1. Python 배포물+OCaml/native engine. Community rule은 별도 **Semgrep Rules License**로 재배포/서비스 제한이 있으므로 registry를 제품에 vendor하지 말고 사용자 rule 또는 허용된 config만 받는다. | **중간** |
+| **Greptile repo graph** | 공개 문서상 repo 전체를 스캔해 directory/file/function/class/variable 노드와 call/import/dependency/usage edge를 저장하고, diff마다 caller·dependency·유사 pattern을 실시간 조회한다. [공식 graph 문서](https://www.greptile.com/docs/how-greptile-works/graph-based-codebase-context) | 목표 아키텍처의 좋은 제품 사례다. 변경 함수→caller/contract→유사 구현을 함께 제시해 ripple effect를 본다. 그러나 parsing, resolver, graph DB, embedding/ranking의 구체 구현은 공개되지 않았다. 공개 설명을 넘어 AST나 저장소 기술을 단정하지 말고 **추론 가능한 정보 모델만** 차용한다. | 상용 proprietary 서비스/API; OSS 라이선스나 내장 가능한 의존성 없음. | **직접 통합 제외** |
+| **CodeQL** | extractor가 소스를 언어별 relational database로 만들고 QL query가 AST, type, control/data flow, call 관계를 질의해 SARIF를 낸다. [CLI 개요](https://docs.github.com/en/code-security/concepts/code-scanning/codeql/codeql-cli) | cross-file security/dataflow와 call graph의 정확도 상한. 이미 CodeQL SARIF가 존재하면 import하는 adapter는 가치가 있지만, 매 로컬 review마다 DB를 생성하는 것은 느리고 무겁다. | query/library 저장소는 MIT지만 engine/CLI는 별도 CodeQL Terms. 비공개 코드의 일반 분석은 GitHub Code Security 상용 라이선스가 필요하다. [라이선스 구분](https://github.com/github/codeql) | **매우 높음/기본 제외** |
+| **tree-sitter `tags.scm`** | grammar 저장소의 `queries/tags.scm`가 `@definition.function`, `@definition.class`, `@reference.call` 등 표준 capture로 named entity를 뽑는다. Python binding의 `QueryCursor`로 직접 실행할 수 있다. [공식 tag 규약](https://tree-sitter.github.io/tree-sitter/4-code-navigation.html), [Python query API](https://github.com/tree-sitter/py-tree-sitter) | 현재 node-type 표를 `Symbol{name, kind, role, range, container}`로 일반화하는 최단 경로. 정의·호출 후보와 repo outline을 한 번에 얻고 Aider ranking의 입력이 된다. 단독으로는 동일 이름 reference를 정확한 정의에 resolve하지 못한다. | Tree-sitter/runtime MIT; 각 grammar/query 라이선스 확인·NOTICE 반영 필요(주요 공식 grammar는 MIT). 이미 있는 Python/tree-sitter stack을 재사용. | **낮음** |
+
+### 3.1 Pure AST, graph, RAG의 트레이드오프
+
+| 방식 | 강점 | 약점 | Selvage 역할 |
+|---|---|---|---|
+| Pure AST/query | 빠름, offline, 재현 가능, line precision, 추가 모델 비용 없음 | 파일 간 binding·동적 dispatch·자연어 의미가 약함 | 변경 심볼, outline, deterministic rule의 **사실 계층** |
+| Symbol/repo graph | caller chain, blast radius, multi-hop 구조 질의, edge provenance | 언어별 resolver와 freshness 관리; heuristic edge의 오탐 | context 후보 확장과 ranking의 **관계 계층** |
+| Vector RAG | “비슷한 validation 구현”, 문서·주석·도메인 용어 등 lexical mismatch 검색 | embedding 비용/모델 의존, chunking·staleness, 근사 검색, caller 증명 불가 | graph 결과가 부족할 때 opt-in **유사도 계층** |
+| Hybrid | AST 경계로 chunk하고 graph neighbor를 우선한 뒤 BM25/vector로 보충 | 평가·튜닝·운영 면적 증가 | 장기 목표; 초기 MVP에는 vector DB 불필요 |
+
+[Pinecone](https://docs.pinecone.io/guides/get-started/overview) 같은 관리형 서비스는 별도 계정·네트워크·코드 유출 정책을 요구한다. 로컬 실험이라면 Apache-2.0이며 Python API, local path, vector/FTS/hybrid search를 제공하는 [LanceDB](https://github.com/lancedb/lancedb)가 맞지만, embedding provider까지 Selvage의 기본 의존성으로 넣지는 않는다. AST 경계 chunking이 고정 line chunk보다 낫다는 최근 cAST 연구도 이 방향을 지지한다([EMNLP 2025 논문](https://aclanthology.org/anthology-files/anthology-files/pdf/findings/2025.findings-emnlp.430.pdf)).
+
+## 4. 핵심 기능을 가져오는 구체 설계
+
+### Cross-file caller chain 추적
+
+`tags.scm`로 각 파일의 definition과 `reference.call`을 뽑고 call node를 가장 가까운 enclosing definition에 귀속한다. import 문을 `module/alias/imported-name`으로 정규화해 우선 resolve하고, 같은 모듈·qualified name·scope를 점수화해 `CALLS(caller, callee, confidence, evidence_range)`를 SQLite에 저장한다. 변경 파일만 content hash로 재색인하고 reverse adjacency로 caller를 찾는다.
+
+리뷰 시에는 `changed line → enclosing symbol → direct callers → callers의 caller(최대 2 hop)`로 확장하되, public API·test·변경 심볼을 직접 import한 edge를 우선하고 hop별 cap과 토큰 budget을 둔다. 동적 dispatch, reflection, monkey patching은 `heuristic`으로 표시하고 “가능한 caller”로 LLM에 전달한다. SCIP index가 있으면 동일 edge를 `precise` provenance로 덮어쓴다. 예를 들어 `normalize_email()`이 `str`에서 `Optional[str]`로 바뀌면 API handler, batch job, test caller의 null handling 부분만 함께 제공한다.
+
+### Deterministic rule matching
+
+기본은 별도 optional extra 또는 자동 탐지된 `sg` binary다. `ast-grep scan --json`을 **변경 파일에만** 실행하고 finding range가 diff와 겹치거나 변경 심볼 내부일 때 채택한다. rule id, severity, matched text, line, message를 구조화하고, 확정 rule은 LLM에게 재탐지시키지 말고 “영향·수정 적합성만 검토”시킨다. 예를 들어 Python의 `subprocess.$F(..., shell=True)` 또는 JS의 string-built SQL rule이 맞으면 주변 함수와 1-hop caller만 첨부한다. rule fixture를 저장해 같은 commit에서 결과가 항상 같음을 CI로 보장한다. Semgrep은 taint가 꼭 필요한 opt-in profile로 뒤에 붙인다.
+
+### Symbol-level name resolution
+
+MVP는 stack-graphs를 이식하지 않는다. `(language, module_path, container, kind, name/signature)`의 stable symbol key를 만들고 다음 순서로 resolve한다: ① 같은 lexical scope, ② explicit import/alias, ③ 같은 module, ④ wildcard/package export, ⑤ repo-wide name 후보. 1~3만 `resolved`, 이후는 `candidate`로 표시한다. Python/TS의 import alias fixture부터 시작하고 Java/Kotlin은 package+type 정보를 추가한다. 장기적으로 사용자가 생성한 SCIP occurrence를 읽으면 compiler-derived symbol ID로 교체할 수 있다. 이 “정확도 provenance”가 단순 이름 일치보다 중요한 안전장치다.
+
+## 5. Selvage AST 고도화 우선순위 추천 TOP 5
+
+점수는 Impact/ Effort 각각 5점 척도이며 Effort가 높을수록 어렵다.
+
+| 순위 | 과제 | Impact | Effort | 위치 | 판단 |
+|---:|---|---:|---:|---|---|
+| **1** | `tags.scm` 기반 공통 Symbol/Reference extractor | 5 | 2 | Quick win | 기존 parser·Python binding 재사용. 모든 후속 graph/rank의 토대 |
+| **2** | SQLite incremental symbol/import/call graph + 1~2 hop caller context | 5 | 3 | Strategic | SMART_CONTEXT의 가장 큰 맹점인 cross-file blast radius 해결 |
+| **3** | Aider식 changed-symbol personalization + token-budget ranking | 4 | 2 | Quick win | graph가 만든 과잉 후보를 prompt 가치로 전환; NetworkX 없이 작은 PageRank도 가능 |
+| **4** | ast-grep optional deterministic rule adapter | 4 | 2 | Quick win | 보안/정책 finding의 재현성 확보와 LLM 비용 절감; CLI JSON 경계로 Rust 격리 |
+| **5** | SCIP optional index consumer/provenance override | 5 | 4 | Bet | 설치된 indexer가 있는 사용자에게 precise resolution 제공; 기본 경로는 아님 |
+
+stack-graphs 직접 도입, CodeQL DB 생성, vector DB 기본 탑재는 high-effort/운영부담 대비 현재 단계의 핵심 문제와 맞지 않아 TOP 5에서 제외한다. Semgrep은 ast-grep MVP가 안정된 뒤 `security` extra로 제공한다.
+
+## 6. 1인 메인테이너용 단계적 범위
+
+| 단계 | 현실적 산출물 | 명시적 비범위 |
+|---|---|---|
+| 1 (1~2주) | `Symbol`, `Reference`, `Edge`, `Provenance` 모델; Python/JS/TS tags query; SQLite content-hash cache; golden fixture | 완전한 type inference, graph DB 서버 |
+| 2 (2~3주) | import-aware resolver, reverse caller 1 hop, token budget/rank, `SMART_CONTEXT_V2` feature flag와 품질 metric | reflection/dynamic dispatch 정확 해석 |
+| 3 (1~2주) | `ast-grep-cli` 자동 탐지/optional extra, JSON adapter, 5~10개 자체 Apache-2.0-compatible rule 및 tests | Semgrep registry 재배포 |
+| 4 (후속) | caller 2 hop, Java/Kotlin package resolution, SCIP 파일 adapter, opt-in local hybrid retrieval 실험 | Rust binding 직접 유지, CodeQL 엔진 내장 |
+
+출력에는 각 block마다 `reason`(`changed`, `caller`, `callee`, `rule`, `ranked-symbol`), `confidence`, `source_range`, `estimated_tokens`를 붙인다. 평가는 언어별 10~20개 fixture에서 **caller recall@K, wrong-definition rate, context tokens, extraction latency, fallback rate**를 측정하고 기존 SMART_CONTEXT와 A/B 비교한다. 이 정도면 Python CLI의 배포 단순성을 지키면서도 Greptile식 repository awareness의 핵심을 작고 검증 가능한 형태로 가져올 수 있다.
+
+## 참고 원칙
+
+- SCIP의 precise navigation은 compiler 정보를 사용하고 search/tree-sitter 기반 탐색은 heuristic이라는 구분을 유지한다([Sourcegraph code navigation](https://sourcegraph.com/docs/code-navigation)).
+- Greptile 세부 아키텍처는 비공개다. 이 문서의 graph storage/retrieval 평가는 공식 문서에 명시된 entity와 관계만 바탕으로 한 설계 추론이다.
+- 라이선스는 2026-07-17 공개 저장소 기준이며, 실제 배포 전 의존 버전의 SPDX와 NOTICE를 다시 확인한다.

--- a/docs/research/external/2026-07-17-engineering-concepts.md
+++ b/docs/research/external/2026-07-17-engineering-concepts.md
@@ -1,0 +1,187 @@
+# 2026 AI Engineering Concepts: 코드 리뷰 도구 관점의 기술 지도
+
+> 조사 기준일: 2026-07-17 (KST)  
+> 범위: 공개 웹의 공식 문서, 원 논문, 원 GitHub 저장소를 우선 확인했다. “최신” 기능은 기준일 현재의 문서 상태이며 빠르게 바뀔 수 있다.
+
+## 한눈에 보는 결론
+
+2026년 AI 엔지니어링의 초점은 “더 좋은 한 번의 프롬프트”에서 **재사용 가능한 능력(Skill), 검증 가능한 반복(Loop), 통제된 실행 환경(Harness), 추적 가능한 품질(Eval & Observability), 명시적 계약(Spec)**으로 이동했다. 다섯 개념은 경쟁 관계가 아니라 층이다. Spec이 성공 조건을 정하고, Skill이 도메인 절차를 공급하며, Harness가 모델·도구·상태를 실행한다. Loop는 관찰과 평가 결과를 다음 행동에 반영하고, observability는 전체 궤적을 증거로 남긴다.
+
+Selvage는 이미 Python CLI, 멀티 LLM, Tree-sitter AST 기반 Smart Context, 대규모 변경의 멀티턴 처리, 자체 MCP 서버와 `get_review_context`를 갖고 있다. 따라서 새 “에이전트 제품”을 별도로 만드는 것보다 이 다섯 층을 리뷰 파이프라인에 명시적으로 분리하는 편이 제품 차별화에 유리하다.
+
+---
+
+## 1. Skill Engineering
+
+### 정의
+
+Skill Engineering은 반복되는 프롬프트, 도메인 지식, 작업 순서, 예제, 템플릿, 결정적 스크립트를 **발견·호출·버전 관리 가능한 능력 단위**로 패키징하는 실무다. Anthropic의 [Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)는 `SKILL.md`의 이름·설명 메타데이터를 상시 노출하고, 실제 지침과 참조 파일·스크립트는 필요할 때만 읽는 progressive disclosure를 사용한다. 이는 매 요청에 긴 시스템 프롬프트를 넣는 방식과 다르다.
+
+[Cursor Rules](https://docs.cursor.com/context/rules)는 같은 문제의 더 가벼운 형태다. `.cursor/rules/*.mdc`에 Always, glob 기반 Auto Attached, Agent Requested, Manual 규칙을 두어 저장소 맥락과 코딩 정책을 재사용한다. Rule은 주로 “어떻게 행동할지”를 지속적으로 주입하고, Skill은 지침 외에도 실행 코드와 산출물 템플릿까지 포함하는 경향이 있다. `AGENTS.md`, Claude Code의 `.claude/skills/`, 다양한 agent-skill 호환 시스템은 이 패턴을 IDE 밖 CLI 에이전트로 확장한다.
+
+### 왜 중요한가 / 커뮤니티 내 위치
+
+Skill은 prompt engineering과 fine-tuning 사이의 운영 계층이다. 모델 가중치를 바꾸지 않고 조직의 리뷰 기준과 도구 사용법을 배포하며, 필요한 지식만 로드해 토큰을 절약한다. 동시에 Skill은 실행 권한을 가진 “소프트웨어 공급망”이므로 출처, 권한, 네트워크 접근, 스크립트 감사가 필수다. Anthropic도 Skill을 소프트웨어처럼 감사하라고 경고한다. 공식 예제와 명세는 [anthropics/skills](https://github.com/anthropics/skills), 상호운용 예는 [huggingface/skills](https://github.com/huggingface/skills)에서 볼 수 있다.
+
+작성은 하나의 좁은 책임, 정확한 trigger 설명(무엇을/언제), 단계별 절차, 좋은/나쁜 예, 실패·중단 조건, 최소 권한 스크립트로 구성한다. 배포는 프로젝트 디렉터리와 Git, 개인 디렉터리, 플러그인/마켓플레이스, API 업로드 중 표면에 맞게 선택한다. 평가는 단순히 “실행됐는가”가 아니라 ① trigger precision/recall, ② 비활성 기준 대비 task success, ③ 토큰·지연 비용, ④ 잘못된 도구 호출과 보안 위반, ⑤ 모델·저장소별 회귀를 고정 데이터셋에서 반복 측정한다. 2026년 [SWE-Skills-Bench](https://arxiv.org/abs/2603.15401)는 실제 저장소 태스크에서 skill의 효과를 분리 측정하려는 흐름을 보여준다.
+
+### 대표 도구/프로젝트
+
+- [Anthropic Agent Skills 문서](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview), [anthropics/skills](https://github.com/anthropics/skills): `SKILL.md` 명세, 템플릿, 예제, 플러그인 배포.
+- [Cursor Rules](https://docs.cursor.com/context/rules): 경로·관련성·수동 호출에 따라 적용하는 저장소 규칙.
+- [AGENTS.md](https://agents.md/): 여러 코딩 에이전트가 읽는 저장소 수준 운영 지침.
+- [skills.sh](https://skills.sh/): 커뮤니티 skill 탐색·설치 생태계. 설치 전 내용과 provenance 감사가 전제다.
+
+### Selvage 적용 아이디어
+
+1. **Review Skill SDK**: `security-review`, `python-api-compat`, `migration-review`처럼 `SKILL.md + rubric.yaml + examples/ + optional scripts/`를 정의하고 CLI·MCP·Claude 플러그인이 같은 패키지를 읽게 한다.
+2. **AST-aware trigger**: 파일 glob만 보지 말고 Tree-sitter 노드, import 변화, public API 변경, SQL/crypto 호출을 trigger feature로 사용해 필요한 skill만 로드한다.
+3. **서명된 배포와 sandbox**: Skill manifest에 버전·해시·권한(파일/명령/네트워크)을 선언하고, 제3자 스크립트는 기본 비활성 및 격리 실행한다.
+4. **Skill eval CLI**: `selvage skill eval`로 golden diff에 대한 발견율, 오탐, 리뷰 중복, 토큰 비용을 no-skill baseline과 모델별로 비교해 PR 품질 게이트로 만든다.
+
+---
+
+## 2. Loop Engineering
+
+### 정의
+
+Loop Engineering은 에이전트가 **상태를 관찰하고, 다음 행동을 선택하고, 외부 피드백으로 평가한 뒤, 종료하거나 수정해 재시도**하도록 제어 루프를 설계하는 일이다. 핵심은 무한히 “다시 생각”시키는 것이 아니라 상태, 검증기, 예산, 종료 조건을 명시하는 것이다.
+
+[ReAct](https://arxiv.org/abs/2210.03629)는 reasoning과 action/observation을 교차시켜 외부 환경에서 계획을 갱신한다. [Reflexion](https://arxiv.org/abs/2303.11366)은 실패의 scalar 또는 언어 피드백을 짧은 reflection memory로 바꾸어 다음 trial을 개선한다. [Self-Refine](https://arxiv.org/abs/2303.17651)은 초안→자기 피드백→수정의 inference-time 반복이다. 한편 RALM(Retrieval-Augmented Language Model)은 그 자체가 개선 루프라기보다 생성 중 검색 결과를 관찰로 공급하는 계열이다. 그러므로 ReAct/Reflexion의 evidence acquisition 구성요소로 보는 편이 정확하다.
+
+### 왜 중요한가 / 커뮤니티 내 위치
+
+코드 리뷰는 한 번의 생성보다 루프에 잘 맞는다. “의심 지점 찾기→정의·호출부 검색→테스트/정적 분석 확인→finding 작성→반증 검색”이 인간 리뷰 과정과 가깝기 때문이다. 하지만 같은 모델이 만든 결론을 같은 모델이 근거 없이 승인하면 self-confirmation이 강화된다. 2026년 [recursive self-improvement survey](https://arxiv.org/abs/2607.07663)가 강조하듯, 자유 형식 자기평가보다 테스트·타입체커·AST invariant 같은 외부 검증기가 강하다. 비용 폭증, 컨텍스트 오염, 반복적 오탐을 막기 위해 max turns, token/cost budget, progress invariant, 동일 상태 감지, human escalation이 필요하다.
+
+### 대표 도구/프로젝트
+
+- [ReAct](https://react-lm.github.io/), [Reflexion](https://arxiv.org/abs/2303.11366), [Self-Refine](https://selfrefine.info/): 행동, 기억, 출력 개선의 세 가지 대표 패턴.
+- [LangGraph](https://github.com/langchain-ai/langgraph): 상태 그래프, checkpoint, human-in-the-loop 기반 장기 실행.
+- [AutoGen](https://github.com/microsoft/autogen), [CrewAI](https://github.com/crewAIInc/crewAI): 복수 역할·에이전트 대화와 반복 실행.
+- [Inspect AI의 ReAct agent](https://inspect.aisi.org.uk/): sandbox, 도구, scorer를 포함한 평가 가능한 loop 구현.
+
+### Selvage 적용 아이디어
+
+1. **Finding verification loop**: 1차 reviewer가 finding 후보를 만들면 verifier가 Smart Context에서 반증 근거와 테스트를 찾고, `supported / uncertain / rejected` 및 증거 라인을 반환한다.
+2. **다모델 debate를 선택적으로 사용**: 고위험 security/API finding만 다른 provider가 비판하게 하고, 합의가 아니라 독립 증거·AST 경로·테스트 결과로 채택한다.
+3. **Active context expansion**: 처음에는 최소 AST 블록을 주고, reviewer가 unresolved symbol이나 call site를 요청할 때만 컨텍스트를 확장해 RALM형 검색 루프의 비용을 통제한다.
+4. **명시적 종료 정책**: 새 증거 없음, 동일 finding hash 반복, budget 초과, 모든 rubric 통과를 종료 조건으로 기록하고 MCP 응답에 종료 이유를 노출한다.
+5. **학습 가능한 reflection memory**: 확인된 오탐/누락만 익명화해 저장소별 review memory 후보로 만들되, 자동 영구 반영 대신 인간 승인과 만료일을 둔다.
+
+---
+
+## 3. Harness Engineering
+
+### 정의
+
+Harness Engineering은 foundation model이 실제 에이전트로 작동하도록 입력, 도구, 메모리, 권한, sandbox, retry, checkpoint, 동시성, 예산, 결과 형식을 중개하는 **실행 기질(runtime substrate)**을 설계하는 일이다. [AI Harness Engineering](https://arxiv.org/abs/2605.13357)은 성능 단위를 모델 단독이 아니라 model–harness–environment 시스템으로 본다.
+
+세 용어를 구분해야 한다. **Agent harness/scaffold**는 모델의 관찰→도구 호출→상태 갱신을 실행한다. **Runtime harness**는 프로세스·컨테이너·비밀·파일시스템·승인·복구 같은 운영 경계를 제공한다. **Evaluation harness**는 고정 task를 여러 trial로 실행하고 transcript와 outcome을 수집해 grader로 채점·집계한다. Anthropic의 [agent eval 안내](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)도 Claude Code 같은 agent harness와 평가 인프라를 명확히 나눈다.
+
+### 왜 중요한가 / 커뮤니티 내 위치
+
+같은 모델도 harness의 컨텍스트 선택, 도구 schema, 오류 반환, timeout, 작업 디렉터리에 따라 결과가 크게 달라진다. 특히 코드 에이전트는 명령 실행과 파일 변경이라는 실제 side effect를 가지므로 재현 가능한 commit, 깨끗한 sandbox, network policy와 artifact 보존이 모델 선택만큼 중요하다. Harness는 loop를 안전하게 돌리고 eval을 공정하게 만드는 공통 기반이다.
+
+### 대표 도구/프로젝트
+
+- [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness): 광범위한 LM task/model adapter와 YAML/CLI 평가.
+- [Inspect AI](https://inspect.aisi.org.uk/): dataset–solver/agent–scorer 조합, MCP 도구, Docker/Kubernetes 등 sandbox, 외부 coding-agent 평가.
+- [DeepEval](https://github.com/confident-ai/deepeval): pytest 유사 LLM/agent eval, tracing과 CI CLI.
+- [Patronus AI](https://docs.patronus.ai/docs): evaluator, experiment, agent failure 분석, production monitoring 및 MCP.
+- [SWE-bench](https://github.com/SWE-bench/SWE-bench), [Terminal-Bench](https://github.com/laude-institute/terminal-bench): 실제 코드/터미널 outcome 기반 harness 벤치마크.
+
+### Selvage 적용 아이디어
+
+1. **ReviewRun 계약**: diff snapshot, base/head SHA, model·prompt·skill versions, context chunks, tool calls, budgets, findings를 하나의 불변 run manifest로 저장해 CLI와 MCP 결과를 재현한다.
+2. **Provider-neutral adapter**: 모델별 retry/structured-output 차이는 adapter에 가두고 동일한 review task와 JSON schema로 비교한다. 멀티턴 chunk 순서도 seed와 함께 기록한다.
+3. **격리된 검증 runtime**: 리뷰 자체는 read-only를 기본으로 하고, 테스트 실행은 임시 worktree/container에서 allowlist 명령·시간·CPU·network 제한 하에 수행한다.
+4. **Selvage eval harness**: 실제 버그 diff, clean diff, adversarial diff를 fixture로 묶고 finding-level precision/recall, severity calibration, localization, cost, p95 latency를 모델×skill×context 전략별로 산출한다.
+5. **checkpoint/resume**: 큰 PR의 파일/청크별 결과를 durable checkpoint로 남겨 provider 장애 후 중복 과금 없이 재개하고 최종 dedup 단계만 다시 실행한다.
+
+---
+
+## 4. Agent Eval & Observability
+
+### 정의
+
+Agent eval은 “좋다”를 task·dataset·grader·metric으로 조작화해 변경 전후를 비교하는 활동이고, observability는 실제 실행의 trace, span, tool call, prompt/model version, token·비용·지연, 오류, 사용자 feedback을 수집해 **왜 그런 결과가 나왔는지** 조사 가능하게 만드는 활동이다. Eval은 주로 사전·반복적 검증, observability는 운영 분포의 가시성이지만, production trace를 regression dataset으로 승격하는 순간 하나의 feedback loop가 된다.
+
+### 왜 중요한가 / 2026 커뮤니티 내 위치
+
+에이전트는 최종 텍스트만 보면 도구를 잘못 골랐는지, 우연히 맞았는지, 실제 환경 상태를 바꿨는지 알 수 없다. 따라서 final outcome과 trajectory를 함께 평가하고 여러 trial에서 성공률과 일관성을 본다. Anthropic은 deterministic grader를 우선하고 필요한 곳에 LLM judge와 인간 교정을 겹치는 “Swiss cheese” 방식을 권한다. 2026년에는 vendor SDK만의 trace에서 [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)와 OTLP export로 수렴해 기존 관측 스택과 연결하려는 움직임이 뚜렷하다.
+
+프로토콜도 계층을 혼동하지 않아야 한다. [Agent Protocol](https://github.com/langchain-ai/agent-protocol)은 framework-neutral runs, threads, store API를 정의한다. “llama-protocol/agent-protocol”이라는 공인 단일 프로젝트는 확인되지 않았으며, 조사상 지칭 가능한 활성 원본은 LangChain의 저장소다. 이는 MCP(도구·컨텍스트 연결), A2A(에이전트 간 통신), OTel(telemetry)과 목적이 다르다.
+
+### 대표 도구/프로젝트
+
+- [Langfuse](https://github.com/langfuse/langfuse): 오픈소스·self-host 가능한 tracing, prompt/dataset/eval 플랫폼이며 OTel을 지원한다.
+- [Helicone](https://github.com/Helicone/helicone): gateway 중심의 provider routing/fallback, 비용·지연, session/agent trace.
+- [Braintrust](https://www.braintrust.dev/docs): trace→annotation→dataset→experiment→CI/online scoring의 폐루프.
+- [AgentOps](https://docs.agentops.ai/v1/introduction): agent session replay, 비용·오류·도구 활동 관측.
+- [LangSmith](https://docs.langchain.com/langsmith/evaluation-concepts): LangChain/LangGraph 친화적 tracing, dataset, offline/online eval.
+- [OpenTelemetry](https://opentelemetry.io/)와 [Agent Protocol](https://github.com/langchain-ai/agent-protocol): vendor-neutral telemetry 및 실행 API 경계.
+
+### Selvage 적용 아이디어
+
+1. **OTel-native review trace**: root `review.run` 아래 `git.diff`, `ast.context`, `llm.call`, `tool.verify`, `finding.merge` span을 만들고 OTLP endpoint가 있을 때만 export한다. 코드·prompt 본문은 opt-in/redaction한다.
+2. **Finding provenance UI/API**: 각 finding에 model/prompt/skill/context hash, 근거 AST node, verifier 결과를 연결해 MCP client가 “왜 이 지적이 나왔나”를 drill-down하게 한다.
+3. **Offline/online dataset flywheel**: 사용자의 accept/dismiss/수정, CI 결과, 실제 회귀를 수집하되 PII·소스 제거 후 hard-negative/golden dataset 후보로 보내고 인간 승인 후 eval에 편입한다.
+4. **품질 SLO**: 단순 호출 성공률 외에 validated finding rate, false-positive proxy, duplicate rate, severity drift, cost/KLoC, p95 time-to-first-finding을 모델·언어·PR 크기별로 모니터링한다.
+5. **exporter plugin**: 로컬 JSONL 기본값을 유지하면서 Langfuse/Helicone/Braintrust/LangSmith는 선택 adapter로 제공해 오픈소스 CLI의 vendor lock-in을 피한다.
+
+---
+
+## 5. Spec-driven Development & Review
+
+### 정의
+
+Spec-driven development(SDD)는 자연어 요청을 바로 코드로 변환하지 않고 **검토 가능한 요구사항과 acceptance criteria→설계→작업→테스트→코드→리뷰**의 추적 가능한 계약으로 바꾸는 방식이다. TDD가 실행 가능한 테스트에서 설계를 밀어 올린다면 SDD는 사용자 의도, 제약, 비기능 요구, 설계 결정을 먼저 안정화하고 테스트와 리뷰가 그 계약을 검증하게 한다.
+
+[GitHub Spec Kit](https://github.github.com/spec-kit/)의 기본 흐름은 Spec→Plan→Tasks→Implement이며 agent별 command와 저장소 구조를 설치한다. [Kiro Specs](https://kiro.dev/docs/cli/v3/specs/)는 `.kiro/specs/<name>/requirements.md`, `design.md`, `tasks.md`를 만들고 단계별 인간 검토와 실행 중 검증을 제공한다. “Amazon Kiro”와 “Kiro”는 별도 도구가 아니라 같은 제품 계열이다. 요청에 적힌 중국어 **专项整治**는 일반적으로 “특별 정비/집중 단속”을 뜻하며, 확인 가능한 SDD 도구·방법론 이름은 아니므로 대표 프로젝트 목록에서는 제외한다.
+
+### 왜 중요한가 / 커뮤니티 내 위치
+
+에이전트가 코드를 더 빨리 생성할수록 잘못된 요구를 빠르게 구현하는 비용도 커진다. Spec은 인간과 에이전트가 성공 조건을 공유하고, 리뷰가 스타일 의견 대신 “어떤 requirement와 test를 만족/위반했는가”를 말하게 한다. 단, 문서가 많다고 정확성이 생기지는 않는다. spec–test–code drift, 오래된 acceptance criteria, agent가 자신이 만든 spec을 느슨하게 해석하는 문제가 있다. 따라서 각 requirement에 안정적 ID를 주고 테스트·변경 코드·finding의 양방향 traceability와 review gate를 자동화해야 한다.
+
+### 대표 도구/프로젝트
+
+- [GitHub Spec Kit](https://github.com/github/spec-kit): agent-agnostic CLI 템플릿과 specify/plan/tasks/implement workflow.
+- [Kiro](https://github.com/kirodotdev/Kiro): requirements-first/design-first/bugfix spec, steering, hooks, MCP.
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec): brownfield 변화에 맞춘 경량 SDD artifact와 change workflow.
+- [Cucumber](https://github.com/cucumber/cucumber), [pytest-bdd](https://github.com/pytest-dev/pytest-bdd): acceptance criteria를 실행 가능한 BDD 테스트로 연결.
+
+### Selvage 적용 아이디어
+
+1. **Spec ingestion**: CLI/MCP가 `.kiro/specs`, Spec Kit artifact, issue/PR body를 자동 탐색하고 requirement ID와 acceptance criteria만 Smart Context에 구조화해 넣는다.
+2. **Traceability review**: `REQ-12 → tests/test_auth.py::test_expiry → changed AST nodes → findings` 그래프를 만들고 미구현 요구, 테스트 없는 요구, 요구 없는 scope creep을 별도 finding 유형으로 낸다.
+3. **Spec-aware rubric**: correctness/security/style 외에 `spec_conformance`, `acceptance_coverage`, `design_deviation`을 추가하되, 모호한 spec은 코드 결함으로 단정하지 않고 clarification으로 분류한다.
+4. **Spec → Test → Code → Review gate**: 구현 전에 테스트 후보의 완전성과 모순을 리뷰하고, 구현 후 fail-to-pass/pass-to-pass 및 AST API 변화를 검증한 뒤 사람이 승인하도록 CI exit code와 SARIF/JSON을 제공한다.
+5. **Drift diff**: spec·test·public API의 세 diff를 함께 비교해 코드만 바뀐 경우뿐 아니라 spec만 완화되거나 테스트가 삭제되어 “통과”한 경우도 경고한다.
+
+---
+
+## 최근 6개월 GitHub Trending Dev Tools — 편집 TOP 15
+
+GitHub Trending은 일/주/월 현재 순위만 제공하고 6개월 공식 archive/API를 제공하지 않는다. 따라서 아래는 **2026-01-17~07-17에 GitHub Trending/주간 순위에 등장했거나 높은 star velocity·release 활동이 관찰된 개발자용 AI 도구**를, 이 보고서와의 관련성·지속 활동으로 재정렬한 편집 순위다. 누적 star 순위나 GitHub 공식 반기 순위로 해석하면 안 된다. 기준일 당일 Trending 페이지에는 skill 저장소와 agent 안전 도구가 상위에 나타났고, 주간 집계도 agent/dev tooling 집중을 보고했다([GitHub Trending](https://github.com/trending), [2026-07-13 주간 스냅샷](https://www.techtarget.com/searchapparchitecture/tip/What-repos-are-trending-on-GitHub)).
+
+1. [anomalyco/opencode](https://github.com/anomalyco/opencode) — provider-agnostic 오픈소스 terminal coding agent.
+2. [openai/codex](https://github.com/openai/codex) — 로컬에서 실행되는 경량 coding-agent CLI.
+3. [anthropics/skills](https://github.com/anthropics/skills) — Agent Skills 명세·템플릿·공식 예제.
+4. [google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) — Gemini 기반 오픈소스 terminal agent와 MCP client/server.
+5. [mattpocock/skills](https://github.com/mattpocock/skills) — 실무 개발 workflow를 패키징한 대형 skill 모음.
+6. [github/spec-kit](https://github.com/github/spec-kit) — agent-agnostic spec-driven development toolkit.
+7. [browser-use/browser-use](https://github.com/browser-use/browser-use) — 웹을 agent action environment로 만드는 브라우저 자동화.
+8. [All-Hands-AI/OpenHands](https://github.com/All-Hands-AI/OpenHands) — sandbox형 software-development agent 플랫폼.
+9. [langfuse/langfuse](https://github.com/langfuse/langfuse) — self-host 가능한 LLM/agent observability와 eval.
+10. [mendableai/firecrawl](https://github.com/mendableai/firecrawl) — agent/RAG를 위한 웹 수집·구조화 API.
+11. [cline/cline](https://github.com/cline/cline) — IDE 안에서 계획·도구·승인을 결합한 coding agent.
+12. [confident-ai/deepeval](https://github.com/confident-ai/deepeval) — LLM/agent 테스트와 tracing을 결합한 Python eval framework.
+13. [UKGovernmentBEIS/inspect_ai](https://github.com/UKGovernmentBEIS/inspect_ai) — sandbox와 외부 agent를 지원하는 AI evaluation framework.
+14. [Dicklesworthstone/destructive_command_guard](https://github.com/Dicklesworthstone/destructive_command_guard) — agent의 위험한 shell/git 명령을 차단하는 runtime guard.
+15. [Nutlope/hallmark](https://github.com/Nutlope/hallmark) — Claude Code, Cursor, Codex용 디자인 품질 skill.
+
+## Selvage 권장 도입 순서
+
+단기에는 `ReviewRun` manifest와 OTel span으로 실행 증거를 고정하고, 실제 diff 기반 golden/clean eval suite를 만든다. 그 위에 spec ingestion과 finding verification loop를 올린다. 마지막으로 검증된 rubric을 Review Skill SDK로 외부화한다. 이 순서는 **관측할 수 없는 loop**와 **평가할 수 없는 skill**을 먼저 확산시키는 위험을 줄인다. 제품 메시지도 “LLM이 리뷰한다”보다 “AST로 필요한 근거를 선택하고, 복수 모델과 검증 루프로 finding을 확인하며, spec부터 결과까지 재현 가능한 증거를 남긴다”로 이동할 수 있다.
+
+핵심 원칙은 간단하다. 생성은 확률적이어도 **입력 snapshot, 실행 권한, 검증기, 종료 조건, provenance와 품질 기준은 결정적으로 관리**해야 한다.

--- a/docs/research/external/2026-07-17-market-landscape.md
+++ b/docs/research/external/2026-07-17-market-landscape.md
@@ -1,0 +1,103 @@
+# AI 코드 리뷰 도구 시장 지형 — 2026년 중반
+
+> 조사 기준일: 2026-07-17 (가격은 USD, 세금 제외). 공식 문서·가격표·변경 로그와 GitHub 원문을 우선했다. 제품명·가격은 변동이 빠르므로 이 문서는 시점 스냅샷이다.
+
+## Executive summary
+
+**핵심 요약.** 시장은 단순 diff 요약에서 저장소 전체를 탐색하고, 사양·조직 규칙을 검증하며, 발견한 문제를 직접 고치는 agentic review로 이동했다. 동시에 전용 SaaS는 $24~30/개발자/월 또는 리뷰별 과금으로 수렴하고, 범용 CLI는 무료 오픈소스/BYOK와 구독형 고성능 에이전트로 양극화된다.
+
+- 가격 경쟁의 기준도 바뀌었다. CodeRabbit Pro는 연간 결제 시 $24/사용자/월, Greptile Pro는 $30/활성 개발자/월+초과 리뷰 $1, Qodo는 좌석이 아니라 월 $30부터의 credit pool, Ellipsis는 예시상 중간 PR 리뷰당 약 $0.74다. 반대로 Claude Code Review는 깊은 멀티 에이전트 검증을 내세우며 평균 $15~25/PR이다. [CodeRabbit 가격](https://www.coderabbit.ai/pricing), [Greptile 가격](https://www.greptile.com/pricing), [Qodo 가격](https://www.qodo.ai/pricing/), [Ellipsis 가격](https://www.ellipsis.dev/pricing), [Claude Code Review](https://support.claude.com/en/articles/14233555-set-up-code-review-for-claude-code)
+- `Greptaper`는 공식 제품·저장소를 확인하지 못했다. `CodeRabbit-GPT5` 역시 별도 제품이 아니라 CodeRabbit이 GPT-5 계열을 멀티모델 파이프라인에서 평가·라우팅한 맥락이다. Qodo의 과거 명칭도 “MergeMate”가 아니라 **Qodo Merge(구 PR-Agent)**이며, 회사명은 CodiumAI에서 Qodo로 바뀌었다. [CodeRabbit 모델 운영 설명](https://www.coderabbit.ai/blog/behind-the-curtain-what-it-really-takes-to-bring-a-new-model-online-at-coderabbit), [Qodo 명칭 안내](https://www.qodo.ai/formerly-qodo-merge/), [Qodo 리브랜딩](https://www.qodo.ai/blog/introducing-qodo-a-new-name-the-same-commitment-to-quality/)
+
+## 1. 상용 경쟁사 최신 상태
+
+**핵심 요약.** 전용 리뷰 업체는 정밀도와 조직별 규칙을, 플랫폼 업체는 GitHub/IDE/에이전트 안에서의 즉시 수정과 배포 연결을 차별점으로 삼는다. 지난 12개월의 공통 업데이트는 멀티 에이전트, 티켓·문서 문맥, 로컬 사전 리뷰, 사용량 과금이다.
+
+| 제품 | 핵심 기능·차별점 | 2026-07 가격 | 최근 12개월 주요 변화 |
+|---|---|---|---|
+| **CodeRabbit** | GitHub/GitLab/Azure DevOps PR 리뷰, linters·SAST 결합, 대화형 수정, multi-repo 분석과 Plan→review→unit test/merge-conflict 해결까지 연결한다. [제품/가격](https://www.coderabbit.ai/pricing) | Pro $24/사용자/월(연간), Pro+ $48, Enterprise 협의·self-host 옵션. [가격](https://www.coderabbit.ai/pricing) | 2026년 Plan, 논리 순서로 PR을 보여주는 Change Stack, 전역 override·감사 로그, Pro+를 추가했다. [changelog](https://docs.coderabbit.ai/changelog) |
+| **Greptile** | 저장소 그래프를 이용한 full-codebase review, 사용자 규칙·feedback 학습, GitHub/GitLab, self-host를 제공한다. 외부 SDK의 파트너 제공 문서까지 출처와 함께 적용하는 점이 독특하다. [문서/변경 로그](https://www.greptile.com/changelog) | Starter 무료(1명, 월 50 standard reviews), Pro $30/활성 개발자/월에 50 credits, 초과 $1/review; Enterprise 협의. [가격](https://www.greptile.com/pricing) | v4에서 업체 측 측정상 addressed comments/PR이 0.92→1.60으로 늘었고, 2026-06 Repo Clusters(최대 7개 관련 repo), partner context, 무료 개인 tier를 출시했다. [v4](https://www.greptile.com/blog/greptile-v4), [changelog](https://www.greptile.com/changelog) |
+| **Qodo** (구 Qodo Merge/PR-Agent) | multi-agent review, PR-history 기반 Context Engine, 중앙 Rule System, IDE·Git·CLI, multi-repo 및 on-prem/air-gap이 강점이다. [Qodo 2 review](https://docs.qodo.ai/code-review), [배포/기능](https://www.qodo.ai/formerly-qodo-merge/) | 영구 무료 tier 없이 14일 trial. Pro Team은 $30/월 2,500 credits(약 18 reviews)부터, $0.012/credit; Enterprise 협의/BYOK/on-prem. [가격](https://www.qodo.ai/pricing/) | 2026-02 Qodo 2.0 GA로 멀티 에이전트 리뷰, 2.1로 규칙 자동 발견·충돌 관리와 Azure DevOps, 2.2로 PR Knowledge와 finding recommendation agent를 도입했다. [changelog](https://docs.qodo.ai/changelog), [2.2](https://www.qodo.ai/blog/qodo-2-2-code-review-that-learns-from-your-pr-history-context/) |
+| **Cursor BugBot** | PR 자동/수동 리뷰, directory-scoped `.cursor/BUGBOT.md`, IDE에서 발견 항목을 즉시 고치는 흐름과 push 전 `/review`를 결합한다. [문서](https://docs.cursor.com/bugbot) | 2026-06부터 좌석 $40 정액을 없애고 사용량 과금; 평균 run $1.00~1.50, effort level로 비용·깊이 조절. [가격 변경](https://cursor.com/blog/may-2026-bugbot-changes) | 2026-06 Composer 2.5 기반으로 평균 약 90초, 업체 측 기준 22% 저렴하고 10% 더 많은 버그를 찾도록 갱신; incremental review와 로컬 `/review` 추가. [changelog](https://cursor.com/changelog/bugbot-updates-june-2026) |
+| **GitHub Copilot code review** | GitHub PR·VS Code에서 inline finding과 적용 가능한 수정안을 만들며, custom instructions뿐 아니라 2026년에는 agent skills와 MCP context도 public preview로 읽는다. 리뷰 모델은 자동 선택이라 사용자가 바꿀 수 없다. [기능](https://docs.github.com/en/copilot/concepts/agents/code-review) | 유료 Copilot에 포함: Pro $10, Pro+ $39, Max $100, Business $19, Enterprise $39/사용자/월. 1 AI credit=$0.01이며 2026-06-01부터 agentic review는 Actions minutes도 소비한다. [플랜](https://docs.github.com/en/copilot/get-started/plans), [과금](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing) | 2026년 usage-based AI credits, 무면허 PR 작성자에 대한 조직 직접 과금, MCP/skills 기반 context와 review effort를 도입했다. [기능/사용량](https://docs.github.com/en/copilot/concepts/agents/code-review), [과금 전환](https://docs.github.com/en/copilot/reference/copilot-billing/request-based-billing-legacy/what-changed-with-billing) |
+| **Sourcegraph** | 전용 리뷰 봇보다는 reviewer/agent 아래의 **retrieval layer**다. cross-repo Code Search, precise navigation, Deep Search, MCP로 callers·tests·관련 변경을 공급한다. Amp는 2025-12 별도 회사가 됐다. [시장 포지션](https://sourcegraph.com/blog/ai-code-review), [분리](https://sourcegraph.com/blog?page=2) | 공개 self-serve 단가는 없고 volume/Enterprise 협의. [가격](https://sourcegraph.com/pricing?product=codeIntelligence) | 2026-02 Sourcegraph 7.0이 “AI agent용 intelligence layer”로 재정의됐고, MCP 및 experimental Agentic Migrations를 확대했다. [7.0](https://sourcegraph.com/blog/a-new-era-for-sourcegraph-the-intelligence-layer-for-ai-coding-agents-and-developers), [agentic coding](https://sourcegraph.com/blog/agentic-coding) |
+| **Bito** | codebase-aware PR/IDE/CLI 리뷰, static analysis·OSS vulnerability 결과 결합, feedback 학습, Jira/Confluence requirement validation, GitHub/GitLab/Bitbucket 및 self-managed를 지원한다. [개요](https://docs.bito.ai/ai-code-reviews-in-git/overview) | Free는 PR summary, Team $12(연간)/$15(월간), Professional $20/$25 per seat; self-host는 Professional에 $5/seat/월 추가, Enterprise 협의. [가격/플랜](https://docs.bito.ai/help/billing-and-plans/overview) | 2025-09 Jira ticket 검증, 11월 `AGENTS.md` 등 agent rule 자동 적용과 `.bito.yaml`, 2026-01 CLI review, 02월 Confluence context를 추가했다. [changelog](https://docs.bito.ai/changelog) |
+| **Ellipsis** | repo 안에 정의한 managed coding agents가 PR 리뷰뿐 아니라 call-site 수정, 테스트 실행, Sentry alert fix와 PR 생성까지 수행한다. 과거 review feedback을 팀 규칙으로 활용하고 BYOK Bedrock/private cloud를 제공한다. [가격·기능](https://www.ellipsis.dev/pricing) | 좌석비 없이 token+CPU+memory+platform fee. 계산기 예시의 중간 PR review는 약 $0.74; 신규 조직 $100 credit, spending cap 지원. [가격](https://www.ellipsis.dev/pricing) | 공개된 정형 changelog는 찾기 어렵지만, 현재 제품은 “리뷰 코멘트”보다 git-push로 배포하는 범용 agent와 action/fix 자동화에 초점을 둔다. [제품/가격](https://www.ellipsis.dev/pricing) |
+| **Greptaper** | 2026-07-17 현재 공식 사이트·문서·활성 GitHub 저장소로 식별되지 않았다. 유사 명칭인 Greptile과 혼동했을 가능성이 높다. | 검증 불가 | 검증 불가. 비교·구매 목록에서는 정확한 vendor URL 확인 전 제외하는 것이 안전하다. |
+| **CodeRabbit-GPT5** | 별도 제품/SKU가 아니다. CodeRabbit은 GPT-5를 “bug-hunting detailed developer”, GPT-5-Codex를 patch generator 성향으로 평가해 서로 다른 pipeline 역할에 배치한다. [모델 분석](https://www.coderabbit.ai/blog/the-end-of-one-sized-fits-all-prompts-why-llm-models-are-no-longer-interchangeable) | CodeRabbit 요금에 포함; 모델별 별도 공개 가격 없음. [가격](https://www.coderabbit.ai/pricing) | 최근 12개월에는 GPT-5·5.1·Codex 등 모델별 eval을 거쳐 prompt와 context packing을 따로 조정하는 multi-model 운영 방식이 공개됐다. [운영 설명](https://www.coderabbit.ai/blog/behind-the-curtain-what-it-really-takes-to-bring-a-new-model-online-at-coderabbit) |
+
+## 2. OSS·CLI 경쟁 지형
+
+**핵심 요약.** 이 그룹은 대개 “전용 PR 리뷰어”가 아니라 로컬 diff를 읽고 테스트·수정까지 할 수 있는 범용 코딩 에이전트다. 따라서 Selvage와의 직접 경쟁은 리뷰 UX보다 무료/BYOK, 모델 선택, MCP, local-first context 조립에서 발생한다.
+
+| 도구 | 리뷰 관점의 상태·차별점 | 가격 및 최근 상태 |
+|---|---|---|
+| **Aider** | git-native 터미널 pair programmer로 repo map, diff/edit format, 자동 commit을 제공해 “변경 검토→수정”을 한 세션에서 수행한다. 여러 provider/OpenRouter를 고를 수 있다. [repo](https://github.com/Aider-AI/aider), [모델 설정](https://aider.chat/docs/troubleshooting/models-and-keys.html) | Apache-2.0 무료+LLM API 비용. 2026-05까지 활동했으며, 모델별 edit format과 비용 metadata를 계속 갱신했다. [releases](https://github.com/Aider-AI/aider/releases), [metadata](https://aider.chat/docs/config/adv-model-settings.html) |
+| **Cline** | VS Code·CLI의 autonomous agent로 Plan/Act, MCP, rules/skills/plugins, command permission, local model을 지원한다. 전용 PR bot보다는 로컬 검토와 실제 수정에 강하다. [repo](https://github.com/cline/cline), [CLI](https://docs.cline.bot/cli/cli-reference) | Apache-2.0 앱 무료; Cline credits/BYOK/provider 사용량 또는 local compute. 2026년 CLI·ACP·scheduler·kanban까지 표면이 넓어졌다. [비용](https://docs.cline.bot/core-workflows/task-management), [CLI](https://docs.cline.bot/cli/cli-reference) |
+| **Continue** | CLI/VS Code/JetBrains, configurable models·rules·MCP와 GitHub Actions PR review recipe를 제공하며 offline/local model도 가능하다. [가이드](https://docs.continue.dev/guides/overview) | Apache-2.0 무료+provider 비용. 다만 2026년 final 2.0.0 뒤 기존 repo를 read-only/비활성 유지로 전환했다고 공지해 신규 채택 리스크가 있다. [공식 상태](https://docs.continue.dev/) |
+| **OpenHands** | model-agnostic autonomous developer로 GUI/TUI/CLI, sandbox, Git/Jira/Slack, Agent SDK·MCP를 제공한다. 이슈 해결·테스트·PR 생성 루프가 중심이다. [repo](https://github.com/OpenHands/OpenHands), [가격](https://www.openhands.dev/pricing/) | 로컬 OSS 무료(MIT), Individual cloud 무료+BYOK/at-cost model, Enterprise 협의. 2026-03 Planning Agent와 skills slash menu를 추가했다. [업데이트](https://www.openhands.dev/blog/openhands-product-update---march-2026) |
+| **Claude Code** | 터미널 agent이며 `/security-review`와 GitHub Action 외에, 2026년 Team/Enterprise용 Code Review research preview가 specialized agent fleet+verification으로 full-codebase PR을 분석한다. `CLAUDE.md`·`REVIEW.md` 규칙을 읽는다. [security review](https://support.claude.com/en/articles/11932705-automated-security-reviews-in-claude-code), [Code Review](https://support.claude.com/en/articles/14233555-set-up-code-review-for-claude-code) | CLI는 Pro $20, Max $100/$200 또는 Team/Enterprise/API; 전용 Code Review는 별도 평균 $15~25/PR. 소스 공개 repo지만 명시적 OSS license가 없어 “CLI”로 보는 편이 정확하다. [플랜](https://support.claude.com/en/articles/11049762-choose-a-claude-plan), [repo](https://github.com/anthropics/claude-code) |
+| **Codex CLI** | 로컬 sandbox/approval, `AGENTS.md`, MCP·web search와 `codex review`를 제공하며, GitHub에서는 PR intent와 전체 codebase를 탐색하고 tests를 실행한 뒤 같은 thread에서 수정까지 위임할 수 있다. [repo](https://github.com/openai/codex), [리뷰](https://openai.com/index/introducing-upgrades-to-codex/) | Apache-2.0 CLI; ChatGPT Plus/Pro/Business/Edu/Enterprise에 포함 또는 API 비용. 2026년 app의 multi-agent 병렬 실행, Hooks·remote SSH와 조직 통제가 추가됐다. [app](https://openai.com/index/introducing-the-codex-app/), [2026 updates](https://openai.com/index/work-with-codex-from-anywhere/) |
+| **Bloop** | Rust semantic code search/repo 이해 도구로 리뷰 context에 인접했지만 전용 reviewer는 아니다. [repo](https://github.com/BloopAI/bloop) | Apache-2.0 무료. repo가 2024-12 이후 업데이트 없이 archived되어 현재 경쟁력은 낮다. [repo 상태](https://github.com/BloopAI/bloop) |
+| **Ruler** | 한 벌의 Markdown rules를 Claude Code, Codex, Cursor, Cline 등 여러 agent 형식으로 배포해 review standard의 vendor lock-in을 줄인다. [repo](https://github.com/intellectronica/ruler) | MIT 무료. 2026-07까지 활발하며, 그 자체가 reviewer라기보다 cross-agent rule distribution layer다. [commits](https://github.com/intellectronica/ruler/commits/main/) |
+| **Refact** | IDE local engine, BYOK/local models, RAG, shell/browser/Git/MCP를 갖춘 agent다. [제품](https://refact.ai/blog/2026/refact-cloud-is-shutting-down/) | 2026-04 Cloud 종료를 발표하고 local-first·BYOK·community-maintained OSS로 전환했다. hosted subscription은 사라지며 provider/local compute만 부담한다. [종료 공지](https://refact.ai/blog/2026/refact-cloud-is-shutting-down/), [repo](https://github.com/smallcloudai/refact) |
+| **Tabby** | self-hosted AI coding assistant/server로 IDE completion·chat와 private deployment가 중심이며 전용 PR review workflow는 약하다. [repo](https://github.com/TabbyML/tabby) | Community/self-host 무료, Enterprise는 별도 계약. 2026-06까지 유지되지만 핵심 차별점은 review precision보다 데이터 통제와 local serving이다. [repo/releases](https://github.com/TabbyML/tabby/releases) |
+
+## 3. 시장 트렌드 5개
+
+**핵심 요약.** 리뷰의 산출물이 “코멘트”에서 “검증된 변경”으로 바뀌고, 품질은 모델 이름보다 어떤 코드·사양·조직 지식을 회수하고 어떤 도구로 검증하느냐에 더 좌우된다.
+
+1. **Autonomous fixing과 closed loop.** BugBot은 push 전 리뷰를, Codex는 review thread에서 수정 위임을, Ellipsis는 테스트가 통과할 때까지 고쳐 PR을 여는 흐름을 제공한다. 리뷰와 구현의 제품 경계가 사라지고 있다. [BugBot](https://cursor.com/changelog/bugbot-updates-june-2026), [Codex](https://openai.com/index/introducing-upgrades-to-codex/), [Ellipsis](https://www.ellipsis.dev/pricing)
+2. **Spec-driven review.** Bito의 Jira·Confluence 검증, CodeRabbit Plan, Qodo ticket/rule compliance처럼 “코드가 문법적으로 맞는가”보다 “요구사항과 acceptance criteria를 구현했는가”가 새 평가 축이다. [Bito changelog](https://docs.bito.ai/changelog), [CodeRabbit changelog](https://docs.coderabbit.ai/changelog), [Qodo](https://www.qodo.ai/formerly-qodo-merge/)
+3. **Repo graph와 institutional memory.** Greptile Repo Clusters, Qodo PR Knowledge, Sourcegraph cross-repo retrieval은 diff 밖의 callers·과거 결정·관련 서비스를 찾는다. 즉 장기 moat는 LLM 자체보다 context graph와 feedback history에 형성된다. [Greptile](https://www.greptile.com/changelog), [Qodo 2.2](https://www.qodo.ai/blog/qodo-2-2-code-review-that-learns-from-your-pr-history-context/), [Sourcegraph](https://sourcegraph.com/blog/ai-code-review)
+4. **멀티 에이전트 검증과 reviewer independence.** Qodo와 Claude는 서로 다른 issue class를 병렬 탐색하고 verification/dedup 단계를 둔다. 하나의 생성 모델이 자기 코드를 단순 재독하는 방식보다 독립 역할·모델·adversarial pass가 신뢰 설계의 핵심이 된다. [Qodo 2.0](https://docs.qodo.ai/code-review), [Claude Code Review](https://support.claude.com/en/articles/14233555-set-up-code-review-for-claude-code)
+5. **Review-action 통합과 usage economics.** GitHub는 review에 AI credits+Actions minutes를, Cursor는 effort별 run 비용을, Greptile은 included review+overage를 부과한다. 정밀한 incremental context, cache, AST selection은 품질 기능인 동시에 gross-margin 기능이 됐다. [GitHub 과금](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing), [Cursor 가격](https://cursor.com/blog/may-2026-bugbot-changes), [Greptile billing](https://www.greptile.com/docs/code-review-bot/billing-seats)
+
+## 4. GitHub momentum — 최근 6개월 TOP 10
+
+**핵심 요약.** 별 증가는 OpenCode·Claude Code·Codex 같은 범용 agent와, 2026년 3월 등장해 review/ship workflow를 skills로 패키징한 gstack에 집중됐다. 이는 전용 reviewer뿐 아니라 “기존 agent에 꽂는 품질 레이어”가 직접 대체재임을 뜻한다.
+
+방법론: GitHub에는 공식 “6개월 trending” 누적표가 없으므로, 2026-03-23 OSS Insight의 동일 카테고리 스냅샷과 2026-07-17 GitHub API 관측값을 비교했다. `gstack`은 2026-03-11 신규 repo라 생성 이후 전량을 증가분으로 보았다. 따라서 아래 `관측 증가`는 엄밀한 2026-01-17 기준이 아니라 **최근 4개월의 검증 가능한 하한치**이며, 현재 stars는 반올림하지 않은 조사 시점 값이다. 별은 관심도 지표이지 실제 사용량·품질 지표가 아니다. [OSS Insight 기준표](https://ossinsight.io/blog/coding-agent-wars-2026), [GitHub Trending](https://github.com/trending)
+
+| 순위 | 저장소 | 2026-07-17 stars | 2026-03 이후 관측 증가 | 한 줄 설명 |
+|---:|---|---:|---:|---|
+| 1 | [garrytan/gstack](https://github.com/garrytan/gstack) | 122,244 | +122,244 | Claude/Codex 등에서 plan→review→QA→ship을 실행하는 opinionated skills 묶음; 2026-03 신규. |
+| 2 | [anomalyco/opencode](https://github.com/anomalyco/opencode) | 186,468 | +58,191 | 멀티 provider·TUI 중심의 오픈소스 코딩 에이전트. |
+| 3 | [anthropics/claude-code](https://github.com/anthropics/claude-code) | 138,081 | +56,644 | repo-aware terminal agent와 hooks/subagents; 전용 PR Code Review의 호스트. |
+| 4 | [openai/codex](https://github.com/openai/codex) | 98,780 | +31,811 | Rust 기반 local agent, sandbox·MCP·내장 review와 cloud handoff. |
+| 5 | [aaif-goose/goose](https://github.com/aaif-goose/goose) | 51,288 | +17,835 | model-agnostic·MCP 확장형 로컬 autonomous agent. |
+| 6 | [OpenHands/OpenHands](https://github.com/OpenHands/OpenHands) | 80,998 | +11,422 | sandboxed software agent platform·SDK와 Git workflow. |
+| 7 | [google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) | 106,021 | +7,286 | Gemini 기반 오픈소스 터미널 agent와 MCP/automation. |
+| 8 | [cline/cline](https://github.com/cline/cline) | 64,722 | +5,470 | VS Code·CLI에서 모델을 골라 파일·명령·브라우저를 조작하는 agent. |
+| 9 | [Aider-AI/aider](https://github.com/Aider-AI/aider) | 47,432 | +5,168 | git-native multi-LLM pair programmer와 repo map. |
+| 10 | [continuedev/continue](https://github.com/continuedev/continue) | 34,914 | +2,917 | configurable IDE/CLI agent; 현재 final 2.0 이후 maintenance 종료 상태. |
+
+## 5. 시장 빈틈과 Selvage의 포지션
+
+**핵심 요약.** 상위 SaaS는 깊은 문맥과 자동 수정을 제공하지만 비용·클라우드 종속·불투명한 모델 선택이 커지고, 범용 agent는 리뷰 전용의 결정적 context packing과 일관된 출력이 약하다. Selvage가 차지할 수 있는 자리는 “어떤 agent/LLM에도 붙는 로컬 review context compiler”다.
+
+### 아직 충분히 채워지지 않은 니치
+
+| 빈틈 | 현재 한계 | 기회 |
+|---|---|---|
+| **진짜 local-first·privacy** | 주요 전용 reviewer의 self-host/on-prem은 Enterprise 협의이며, Claude Code Review는 zero-data-retention 조직에서 사용할 수 없다. [Greptile](https://www.greptile.com/pricing), [Qodo](https://www.qodo.ai/pricing/), [Claude](https://support.claude.com/en/articles/14233555-set-up-code-review-for-claude-code) | 로컬 diff/AST 처리, BYOK/local OpenAI-compatible endpoint, 전송 전 context preview·redaction을 무료 기본값으로 제공. |
+| **사용자가 통제하는 multi-LLM** | Copilot review는 모델 switching을 지원하지 않고, CodeRabbit은 내부 라우팅을 공개 가격 단위로 노출하지 않는다. [Copilot](https://docs.github.com/en/copilot/concepts/agents/code-review), [CodeRabbit](https://www.coderabbit.ai/blog/behind-the-curtain-what-it-really-takes-to-bring-a-new-model-online-at-coderabbit) | 같은 context에 2개 모델을 병렬 실행하고 합의/불일치·비용·latency를 비교하는 reviewer council. |
+| **MCP-native review primitive** | GitHub·Sourcegraph가 MCP를 받아들이지만 대부분은 기존 제품에 추가된 context channel이다. [GitHub](https://docs.github.com/en/copilot/concepts/agents/code-review), [Sourcegraph](https://sourcegraph.com/blog/agentic-coding) | `get_review_context`, `review_diff`, `validate_finding`, `apply_fix`를 작고 조합 가능한 MCP tools로 설계해 모든 host agent에서 재사용. |
+| **무료 self-hosted review gate** | Continue는 maintenance 종료, Bloop은 archived, Refact는 community-only로 전환했다. [Continue](https://docs.continue.dev/), [Bloop](https://github.com/BloopAI/bloop), [Refact](https://refact.ai/blog/2026/refact-cloud-is-shutting-down/) | GitHub Actions/GitLab CI용 headless JSON/SARIF, deterministic exit code, budget ceiling을 제공하는 가벼운 OSS gate. |
+| **비영어권·한국어 품질** | Bito는 20+ 출력 언어를 지원하지만, 시장 리더의 규칙 예시·온보딩·평가셋은 영어 중심이다. [Bito plans](https://docs.bito.ai/help/billing-and-plans/overview) | 한국어 finding·commit/PR 요약뿐 아니라 한국어 요구사항→코드 compliance benchmark와 bilingual rule pack을 제공. |
+| **커스텀 rule plugin 생태계** | `.coderabbit.yaml`, `.greptile/`, Qodo Rule System 등 vendor별 규칙 형식이 파편화됐다. [CodeRabbit](https://docs.coderabbit.ai/changelog), [Greptile](https://www.greptile.com/changelog), [Qodo](https://docs.qodo.ai/changelog) | `AGENTS.md`/`REVIEW.md`/Ruler 규칙을 읽는 adapter와 언어·프레임워크별 review plugin registry를 만든다. |
+
+### Selvage: 현재 위치와 차별화 우선순위
+
+Selvage는 Apache-2.0 Python CLI로 staged/unstaged/branch/commit diff를 리뷰하고, OpenAI·Anthropic·Google·OpenRouter를 선택할 수 있다. Tree-sitter AST로 변경 라인을 감싸는 최소 code block과 dependency statements를 추출하고, 큰 입력은 multi-turn으로 나누며, 자체 MCP server와 host agent가 자체 LLM으로 리뷰하게 하는 `get_review_context`를 이미 제공한다. [Selvage README](https://github.com/selvage-lab/selvage), [PyPI](https://pypi.org/project/selvage/)
+
+현재 포지션은 CodeRabbit/Greptile 같은 SaaS PR lifecycle 제품보다 **Aider·Cline과 전용 SaaS 사이의 로컬 review engine/context layer**에 가깝다. Sourcegraph가 enterprise cross-repo retrieval layer라면 Selvage는 개인·소팀용 AST-precise diff context layer가 될 수 있다. 특히 host agent의 기존 구독/모델을 그대로 쓰게 하는 MCP delegated review는 별도 per-seat/per-review 과금과 모델 lock-in을 동시에 피한다. [Selvage MCP 설명](https://github.com/selvage-lab/selvage#agent-delegated-review-no-api-key-required), [Sourcegraph 포지션](https://sourcegraph.com/blog/ai-code-review)
+
+우선순위는 다음과 같다.
+
+1. **“AST context가 더 싸고 정확하다”를 수치화한다.** 동일 PR에서 raw diff/full-repo/RAG 대비 input tokens, file recall, accepted finding rate, false-positive rate를 공개 benchmark로 만든다. 시장이 model claim보다 retrieval evidence를 요구하기 시작했다. [Sourcegraph의 retrieval 논점](https://sourcegraph.com/blog/ai-code-review)
+2. **reviewer에서 verifier로 확장한다.** finding마다 AST path·관련 call site·실행한 test를 evidence로 붙이고, 선택적으로 patch 생성→test→재리뷰까지 닫힌 루프를 제공한다. 이는 Codex·Claude의 verification 방향과 경쟁하되 로컬·멀티 LLM으로 차별화한다. [Codex review](https://openai.com/index/introducing-upgrades-to-codex/), [Claude review](https://support.claude.com/en/articles/14233555-set-up-code-review-for-claude-code)
+3. **MCP를 배포 채널로 만든다.** Claude Code 플러그인에 더해 Cursor/Codex/Cline/OpenHands용 설치 recipe, stable JSON schema, SARIF와 CI exit policy를 제공한다. MCP가 보편화될수록 host UI보다 잘 조립된 review context와 검증 도구가 Selvage의 moat가 된다. [Selvage README](https://github.com/selvage-lab/selvage), [OpenHands MCP](https://www.openhands.dev/pricing/)
+4. **한국어와 open rule packs를 선점한다.** Django/FastAPI, Spring, React, 보안·개인정보, 한국 전자금융/공공 규칙의 bilingual packs와 한국어 ticket compliance를 커뮤니티 plugin으로 배포한다. 범용 글로벌 SaaS가 경제적으로 깊게 현지화하기 어려운 면이다.
+
+결론적으로 Selvage가 피해야 할 경쟁은 “또 하나의 GitHub 코멘트 봇”이다. 가장 방어력 있는 메시지는 **로컬에서 코드를 구조적으로 압축하고, 원하는 LLM이나 코딩 에이전트에 검증 가능한 review context를 공급하는 오픈 품질 레이어**다. 이 포지션은 프라이버시·비용 통제·멀티 LLM·MCP·한국어라는 아직 분산된 수요를 하나의 일관된 CLI에 묶는다.

--- a/docs/research/external/2026-07-17-sprint-1-ast-comparison.md
+++ b/docs/research/external/2026-07-17-sprint-1-ast-comparison.md
@@ -1,0 +1,238 @@
+# Selvage Sprint 1 AST V2 고도화를 위한 OSS 도구 심층 비교
+
+> 조사일: 2026-07-17 · 관점: 1인 메인테이너, Python CLI, tree-sitter 기반 smart context
+> 성격: 비교 지도(comparison atlas) — 선행 리서치 [`2026-07-17-ast-context-research.md`](./2026-07-17-ast-context-research.md)(처방형)와 직교하는 **횡단 비교** 관점
+
+## 1. Executive Summary
+
+현재 `ContextExtractor`는 단일 파일의 라인 범위를 AST 노드로 매핑하는 1차원 파이프라인이다. tree-sitter를 파서로만 쓰고 Query/tags.scm API는 쓰지 않으며, 노드 타입을 딕셔너리에 하드코딩한다. cross-file caller·name resolution·심볼 그래프·AST 캐시·토큰 랭킹이 모두 부재하다.
+
+15종 OSS 비교 결론: heavyweight 런타임(CodeQL/Joern/Semgrep/scip-python/stack-graphs)의 직접 도입은 전면 배제한다. 대신 1인 메인테이너에게 최적인 세 축은 — Aider의 Personalized PageRank 랭킹(repomap.py로 검증된 엣지 가중치와 SQLite diskcache), SCIP 데이터 모델의 스키마만 차용(enclosing_range·SymbolRole bitset), tree-sitter 공식 tags.scm으로 하드코딩 대체 — 이다. code-review-graph(tirth8205)가 selvage와 동일 스택의 가장 가까운 벤치마크로 새롭게 식별되었다. 임베딩/벡터는 학술·산업 양쪽에서 AST 기반에 밀리므로 현 시점 도입하지 않는다. "Selena"라는 범용 AST OSS는 미확인이다.
+
+## 2. 현재 SMART_CONTEXT 구현 분석 (코드 직접 인용)
+
+> 참고: 요청 경로 `selvage/src/utils/prompts/context_extractor.py`, `resources/language_configs/`는 **존재하지 않는다**. 실제 위치는 `selvage/src/context_extractor/`이며 언어 설정은 별도 디렉토리가 아닌 클래스 변수에 하드코딩된다.
+
+### 2.1 구현 구조와 알고리즘
+
+`ContextExtractor.extract_contexts(file_content: str, changed_ranges)`(`context_extractor.py:215`)는 단일 파일 문자열만 받는다. 8단계 파이프라인: AST 파싱 → 각 변경 라인을 DFS로 가장 작게 감싸는 노드 탐색 → 부모 방향으로 `block_types` 매칭 → import 노드 별도 수집 → 포함 관계 중복 제거 → 텍스트 직렬화.
+
+```python
+# context_extractor.py:352-369 — DFS 라인-노드 탐색 (tree-sitter Query 미사용, 수동 순회)
+def _find_node_by_line(self, root: Node, line_no: int) -> Node:
+    for child in root.children:
+        if child.start_point[0] + 1 <= line_no <= child.end_point[0] + 1:
+            return self._find_node_by_line(child, line_no)
+    return root
+```
+
+### 2.2 강점 (코드 기반 사실)
+
+- 파일당 1회 파싱, `MeaninglessChangeFilter`가 1줄 주석/공백 변경을 사전 제거
+- `_filter_nested_blocks()`로 부모-자식 포함 시 외부 블록만 유지(토큰 절약)
+- Python 데코레이터 보존, JS/TS `require()` 동적 감지, 코틀린 import 주석 제거 등 디테일
+- 폴백 정규식이 C/C++/Go/Rust/Swift/Dart/PHP/Ruby/Perl import 패턴 커버
+
+### 2.3 약점과 정확한 한계 (코드 증거)
+
+| 한계 | 상태 | 코드 증거 |
+|---|---|---|
+| **tree-sitter Query / tags.scm 미사용** | 수동 DFS·상향 탐색만 | `Query`/`captures` grep 결과 0건, `context_extractor.py:352-397` |
+| **노드 타입 하드코딩** | 언어별 딕셔너리 3종 | `LANGUAGE_BLOCK_TYPES`(`:33-111`), `LANGUAGE_DEPENDENCY_TYPES`(`:114-157`) |
+| **AST 지원 언어** | 5개만 | `SUPPORTED_LANGUAGES = ["python","javascript","typescript","java","kotlin"]`(`:30`) |
+| **감지-지원 갭** | 17개 감지 중 12개 강제 폴백 | `language_detector.py:3-29` (go/ruby/php/csharp/cpp/c 미지원) |
+| **cross-file caller** | 구조적 불가(단일 `file_content` 입력) | `context_extractor.py:215-216` |
+| **name resolution / import 해석** | 없음 | `resolve`/`scope`/`symbol_table` grep 0건 |
+| **AST 파싱 캐시** | 없음(매번 재파싱) | 기존 `cache/`는 LLM 결과 캐시 전용 |
+| **incremental parsing** | 미사용(`old_tree` 인자 없음) | `self._parser.parse(code_bytes)`(`:250`) |
+| **토큰 예산/랭킹** | 없음(줄 수 휴리스틱만) | `smart_context_utils.py:14-26` |
+| **심볼 그래프 모델** | 존재 안 함 | `Symbol`/`Reference`/`Edge` 클래스 0건 |
+
+`use_smart_context()`는 단순 휴리스틱이다:
+
+```python
+# smart_context_utils.py:14-26 — 랭킹 없이 줄 수만으로 smart/full 결정
+if total_changes <= 5: return True
+if total_lines < 30: return False
+change_ratio = total_changes / total_lines
+return change_ratio <= 0.2
+```
+
+## 3. OSS 도구 비교표
+
+| 도구 | 핵심 접근법 | 언어 지원 | 라이선스 | 활성도(2026-07) | selvage 적용 가능성 |
+|---|---|---|---|---|---|
+| **tree-sitter tags.scm** (표준) | `@definition.*`/`@reference.*` 캡처 선언적 symbol 추출 | tree-sitter grammar 전체(~40+) | MIT/Apache(언어별) | GitHub code nav·Helix·Neovim·Aider 사용 | **높음** — 하드코딩을 표준 쿼리로 대체 |
+| **Aider repo map** | tags.scm + **Personalized PageRank** + 엣지 가중치 + binary search 토큰 fitting | 30+ | Apache-2.0 | 47.4k stars, 2026-05 최신, 활발 | **높음** — 알고리즘 직접 차용 가능 |
+| **SCIP(프로토콜)** | Protobuf Symbol/Role/Occurrence/Relationship 모델 | 언어 독립 | Apache-2.0 | 2026-03 커뮤니티 이관(Meta/Uber) | **중간** — 스키마 참고 강력 권장, 전체 스택 반대 |
+| **code-review-graph**(tirth8205) | tree-sitter + SQLite + **blast-radius minimal set** + FTS5 | 20+ | (repo 확인) | ~20k stars, 코드 리뷰 특화 | **매우 높음** — selvage와 가장 유사한 벤치마크 |
+| **ast-grep** | tree-sitter + YAML structural rule | 20+ | **MIT** | 15.1k stars, 전일 커밋, 매우 활발 | **중간~높음** — CodeRabbit이 리뷰에 사용(검증됨) |
+| **Semgrep CE** | 패턴 매칭 + intra-function dataflow | 40+ | LGPL-2.1 | 15.9k stars, 활발 | **낮음** — wheel 43-75MB, 철학만 차용 |
+| **Joern (CPG)** | AST+CFG+DDG+CDG 단일 그래프 | 12 | Apache-2.0 | 3.2k stars, 거의 매일 릴리스 | **낮음(직접)** — JVM/Scala/8GB+, 모델링 아이디어만 |
+| **CodeQL** | 관계형 DB + QL dataflow/taint | 12 | repo MIT / engine 상용 | 9.8k stars, 활발 | **낮음(직접)** — JVM+200-400MB+DB 빌드 |
+| **Tabby** | tree-sitter tags + RAG 임베딩 | tree-sitter 전체 | Apache-2.0 | ~25k stars, 활발 | **낮음** — GPU/벡터 인덱스 과중, 단 "임베딩 도구도 tree-sitter 쓴다"는 역발견 |
+| **Greptile** | AST graph + docstring LLM 생성 → 임베딩 + agent swarm | 다양 | 상용 SaaS | YC W24, 활발 | **낮음(직접)** — "AST가 주, 임베딩은 보조" 설계 참고 |
+| **Comby** | parser combinator 런타임 + `:[hole]` lexical 매칭 | ~전체 | Apache-2.0 | 2.7k stars, 활동 둔화 | **낮음** — AST 아님, Python 바인딩 약함 |
+| **LSIF** | JSON Lines vertex/edge 포맷(SCIP 전신) | 언어 독립 | MIT(스펙) | **사실상 deprecated**(lsif.dev 2025-06 archived) | **배제** |
+| **tree-sitter-stack-graphs** | `.tsg` DSL push/pop name resolution | 4개 공식 | MIT/Apache | **2025-09-09 archived** | **배제**(죽은 기술, Python 규칙 미성숙) |
+| **Bloop** | Rust+Tantivy+Qdrant 임베딩 하이브리드 | 언어 무관 | AGPL-3.0 | **2025-01-02 archived** | **배제**(중단) |
+| **"Selena"** | (이름 변형 Selene/Sema/Caelena 포함 폭검색) | — | — | 확인 불가 | 범용 AST code intelligence OSS로 **미확인**(selene은 Lua linter로 이름만 유사) |
+
+## 4. 기능 매트릭스 — selvage와 각 도구 비교
+
+이 표가 본 문서의 핵심 차별화(선행 리서치에 없는 횡단 비교)다.
+
+| 기능 | selvage 현구조 | Aider | SCIP | code-review-graph | ast-grep | Joern(CPG) | CodeQL | 임베딩계(Bloop/Tabby/Greptile) |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Cross-file caller** | ✗(단일 파일) | 파일 PageRank(심볼 정확도 낮음) | 정확(Pyright) | call edge+blast radius | ✗ | 정확(call graph) | 정확 | 의미적 유사도만 |
+| **Name resolution** | ✗ | 문자열 매칭 | 타입 추론(높음) | tree-sitter+옵션 Jedi | ✗ | scope+DDG | compiler-grade | ✗ |
+| **Deterministic rules** | ✗ | ✗ | ✗ | ✗ | **강함**(YAML rule) | 강함(CPGQL) | 강함(QL) | ✗(비결정적) |
+| **Repo graph 모델** | ✗(Symbol/Edge 0건) | 파일 노드 PageRank | Symbol/Occurrence/Relationship | Symbol/Edge | — | **AST+CFG+DDG+CDG** | relational DB | 임베딩 벡터 |
+| **Token efficiency** | 중간(포함관계 제거만) | **매우 높음**(ranked map) | N/A | **매우 높음**(38-528x 절감) | — | 높음(slicing) | — | 중간(노이즈 혼재) |
+| **Incremental cache** | ✗(매번 재파싱) | SQLite diskcache+mtime | Document 단위 | SQLite+SHA-256(<2s/2900파일) | ✗(상태 없음) | flatgraph DB | relational DB | sharded 인덱싱(무거움) |
+
+**아키텍처 패턴 분류**(선행 리서치에 없는 관점): selvage는 **Query-only 패턴**(매번 AST 순회, 상태 없음)에 속한다. Aider/code-review-graph는 **File-local index 패턴**, stack-graphs는 **Name-binding DSL 패턴**, SCIP/CodeQL은 **Compiler index 패턴**, Greptile은 **Service-side graph 패턴**이다. Sprint 1은 Query-only → File-local index로의 이동이 핵심이다.
+
+## 5. Top 5 도입 우선순위 (1인 메인테이너 관점)
+
+| 순위 | 도입 항목 | Impact | Effort | 근거 |
+|---|---|:---:|:---:|---|
+| **1** | **tree-sitter `tags.scm` 도입** | 높음 | 낮음 | 하드코딩 3종 딕셔너리를 표준 쿼리로 대체. `@reference.call` 캡처로 역방향 의존성을 "무상" 획득. 언어 확장 비용 사실상 제로. Aider가 ctags→tags.scm으로 간 이유와 동일 |
+| **2** | **Aider식 Personalized PageRank 랭킹** | 높음 | 낮음~중간 | `repomap.py` 소스 검증. "변경 파일이 참조하는 심볼 ×50" 가중치를 diff에 즉시 적용. `networkx.pagerank`+`diskcache` pip 설치로 해결, 완전 결정적 |
+| **3** | **SQLite cache + SHA-256 incremental** | 높음 | 낮음 | code-review-graph/Aider/CodeGraph 모두 입증. 표준 `sqlite3`로 외부 의존 0. FTS5로 FALLBACK_CONTEXT 정규식 대체. 2,900 파일 <2초 |
+| **4** | **code-review-graph 직접 벤치마크** | 높음 | 낮음(조사만) | selvage와 **동일 스택**(Python+tree-sitter+SQLite+코드 리뷰 특화). blast-radius minimal set, confidence 라벨(EXTRACTED/INFERRED/AMBIGUOUS) 등 최소 스키마를 그대로 참조 |
+| **5** | **SCIP 영감 Symbol/Reference/Edge 스키마** | 중간 | 중간 | `Occurrence.enclosing_range`(이미 SMART_CONTEXT가 하는 일을 표준화), `SymbolRole` bitset, `Relationship` 플래그만 발췌. **전체 스택(scip-python)은 Kind=0 버그(#212)+Node.js 의존으로 반대** |
+
+**배제**: CodeQL/Joern/Semgrep 런타임 직접 도입(전부 비현실적), LSIF(deprecated), stack-graphs(archived), Bloop(archived), 임베딩/벡터 DB(비결정성+인프라 과중).
+
+## 6. Sprint 1 AST V2 구체적 권고사항
+
+### 6.1 tags.scm 도입 경로
+
+`tree_sitter_language_pack`이 이미 설치되어 있으므로, Aider 방식대로 각 언어의 `queries/tags.scm`을 번들한다(Python은 350 bytes, 4개 패턴). 핵심은 definition/reference 이원 구분이다:
+
+```scheme
+;; tree-sitter-python queries/tags.scm (표준)
+(function_definition name: (identifier) @name) @definition.function
+(class_definition  name: (identifier) @name) @definition.class
+(call function: [(identifier) @name
+                 (attribute attribute: (identifier) @name)]) @reference.call
+```
+
+이것만으로 `LANGUAGE_BLOCK_TYPES` 하드코딩(`context_extractor.py:33-111`, 5언어×수십 타입)을 대체하고, 현재 없는 역방향 호출 추적(`@reference.call`)의 기반을 확보한다. 모든 공식 grammar의 tags.scm은 MIT/Apache라 라이선스 리스크가 없다. tree-sitter의 `test/tags/` 주석 기반 테스트(`; ^ definition.function`)를 그대로 활용해 AST 추출 로직을 표준 프레임워크로 검증할 수 있다.
+
+### 6.2 SQLite cache 전략 (code-review-graph 검증 패턴)
+
+```sql
+CREATE TABLE files (
+    file_path TEXT PRIMARY KEY,
+    content_hash TEXT,    -- SHA-256, 변경 감지 핵심
+    mtime REAL,
+    language TEXT
+);
+CREATE TABLE symbols (
+    id INTEGER PRIMARY KEY,
+    name TEXT, kind TEXT,                -- function|class|method|variable|module
+    file_path TEXT REFERENCES files(file_path),
+    start_line INTEGER, end_line INTEGER,
+    signature TEXT, docstring TEXT       -- signature~10-50 토큰
+);
+CREATE TABLE edges (
+    source_id INTEGER REFERENCES symbols(id),
+    target_id INTEGER REFERENCES symbols(id),
+    edge_kind TEXT,                       -- calls|imports|inherits|implements
+    role INTEGER,                         -- SCIP SymbolRole 영감: Def=1,Ref=2,Write=4,Read=8
+    confidence TEXT                       -- EXTRACTED|INFERRED|AMBIGUOUS
+);
+CREATE VIRTUAL TABLE symbols_fts USING fts5(name, signature, docstring);
+```
+
+증분 흐름: 파일 SHA-256 → `files.content_hash` 비교 → 변경 파일만 재파싱 → dependent(역방향 edge) 노드만 갱신. `diskcache.Cache`에 `{mtime, data:[Tag]}` 저장 + `CACHE_VERSION`으로 구 캐시 자동 무효화(Aider 패턴). 이것은 현재 매 리뷰마다 `ContextExtractor(file.language)`를 새로 생성하고 `parser.parse()`를 반복하는 낭비(`prompt_generator.py:110`)를 제거한다.
+
+### 6.3 Aider식 ranking 적용 (repomap.py 소스 인용)
+
+Aider의 엣지 가중치 공식을 diff에 맵핑한다(`aider/repomap.py` 직접 인용):
+
+```python
+# 변경 파일을 Aider의 chat_rel_fnames(×50 부스트 대상)로 취급
+personalization = {fname: 50.0 for fname in diff_changed_files}
+mul = 1.0
+if ident in mentioned_idents:   mul *= 10    # LLM 언급 식별자
+if is_meaningful(ident, len>=8): mul *= 10    # snake/camel 의미 식별자
+if ident.startswith("_"):       mul *= 0.1   # private 억제
+if len(defines[ident]) > 5:     mul *= 0.1   # 과다 정의 억제
+if referencer in chat_rel:      use_mul *= 50  # ★변경 파일의 참조 = 최우선
+num_refs = math.sqrt(num_refs)               # 참조 빈도 √n 감쇠
+G.add_edge(referencer, definer, weight=use_mul*num_refs, ident=ident)
+ranked = nx.pagerank(G, weight="weight", personalization=personalization, dangling=personalization)
+```
+
+핵심 차용: 수식 전체가 아닌 (a) personalization 개념, (b) "변경 파일 참조 ×50", (c) √(참조빈도) 감쇠, (d) binary search 토큰 fitting(`--map-tokens` 예산 내 상위 N개). `nx.pagerank`의 power iteration(tol=1e-06 고정, 난수 없음)은 **완전히 결정적**이라 동일 diff → 동일 컨텍스트를 보장한다. 이것이 임베딩 접근 대비 결정적 리뷰 도구에서 가지는 결정적 장점이다.
+
+### 6.4 Symbol/Reference/Edge 모델 스키마 (SCIP 영감)
+
+SCIP `scip.proto`에서 Python에 필요한 것만 축소 발췌:
+
+| SCIP 엔티티 | selvage 제안 | 설계 영감 |
+|---|---|---|
+| `Symbol`(정규화 ID `<scheme> <module> <descriptor>`) | `Symbol(id,name,kind,file_path,start_line,end_line)` | ID 포맷 패턴 차용 |
+| `Occurrence.symbol_roles`(7-bit bitset) | `Reference.role`(Definition/Read/Write/Import 4-5개) | diff 변경 유형 분류 |
+| `Occurrence.enclosing_range`(v0.9 신규) | `Reference.enclosing_symbol_id`(FK) | **이미 SMART_CONTEXT가 하는 일** — 부모 함수/클래스 추적을 표준화 |
+| `Relationship.is_implementation/is_type_definition` | `Edge.kind`(calls/imports/inherits/implements) | 다중 관계 표준화 |
+| `SymbolInformation.kind`(86개) | `Symbol.kind`(5-7개) | Python 필요분만 |
+
+주의: `overflow_symbol_roles`는 proposal 단계(Issue #154)로 v0.9 미구현. 현재 `int32` 비트마스크(32비트 중 7비트 사용)로 충분하다.
+
+### 6.5 정밀도 계층과 provenance 원칙
+
+선행 리서치의 핵심 철학을 계승: tree-sitter 기반은 heuristic(신뢰도 `EXTRACTED`/`INFERRED`), SCIP/CodeQL은 compiler-precise(`precise`)로 **provenance를 라벨로 분리**한다. Sprint 1은 heuristic 계층만 다루고, 향후 SCIP consumer를 **선택적 외부 adapter**로 둘 수 있도록 스키마를 열어둔다.
+
+### 6.6 핵심 논증: 왜 deterministic AST인가
+
+세 가지 독립 검증이 임베딩 단독 대비 AST graph를 지지한다. (1) **LLMxCPG**(USENIX Security 2025): CPG slicing으로 코드 67-84% 축소 시 LLM F1 15-40% 개선, slicing 생략 시 정확도 급락(0.7250→0.4875). (2) **GitLab**: "AST-based graphs outperform RAG in code reviews by 21%". (3) **arXiv 2601.08773**: AST 파생 그래프가 LLM 추출 지식그래프/일반 RAG 대비 우수. 결정적으로 **임베딩 도구 Tabby조차** 공식 문서에 "parses relevant code into Tree Sitter tags to provide effective prompts"라고 명시하며, 가장 정교한 임베딩 상용 도구 Greptile조차 AST graph를 주축으로 삼는다. 임베딩의 비결정성(같은 diff, 다른 컨텍스트)은 리뷰 도구에서 치명적이며, deterministic AST는 변동 원인을 LLM 호출 한 곳으로 격리한다.
+
+## 7. 참고 링크
+
+**selvage 현 구현 (직접 인용 원본)**
+- `selvage/src/context_extractor/context_extractor.py` — `LANGUAGE_BLOCK_TYPES`(L33-111), `_find_node_by_line`(L352), `_find_minimal_enclosing_block`(L371), `_collect_dependency_nodes`(L521)
+- `selvage/src/utils/prompts/prompt_generator.py:106-144` — smart/fallback/full 분기
+- `selvage/src/context_extractor/smart_context_utils.py:14-26` — `use_smart_context()` 휴리스틱
+
+**tree-sitter / tags.scm**
+- tree-sitter Code Navigation: https://tree-sitter.github.io/tree-sitter/4-code-navigation.html
+- tree-sitter-python tags.scm: https://github.com/tree-sitter/tree-sitter-python/blob/master/queries/tags.scm
+- tree-sitter-javascript tags.scm: https://github.com/tree-sitter/tree-sitter-javascript/blob/master/queries/tags.scm
+
+**Aider (랭킹 알고리즘)**
+- repomap.py 소스: https://github.com/Aider-AI/aider/blob/main/aider/repomap.py
+- Repo map 블로그: https://aider.chat/2023/10/22/repomap.html
+- 알고리즘 분석(NousResearch): https://github.com/NousResearch/hermes-agent/issues/535
+
+**SCIP / LSIF / stack-graphs**
+- scip-code/scip: https://github.com/scip-code/scip · scip.proto: https://github.com/scip-code/scip/blob/main/scip.proto
+- SCIP 거버넌스 전환: https://sourcegraph.com/blog/the-future-of-scip
+- scip-python Issue #212 (Kind=0 버그): https://github.com/sourcegraph/scip-python/issues/212
+- Eric Fritz LLM Antihallucinogen: https://www.eric-fritz.com/articles/llm-antihallucinogen
+- LSIF (archived): https://lsif.dev/ · stack-graphs (archived 2025-09-09): https://github.com/github/stack-graphs
+
+**LLM 코드 리뷰 벤치마크**
+- code-review-graph (tirth8205): https://github.com/tirth8205/code-review-graph
+- CodeGraph (colbymchenry): https://github.com/colbymchenry/codegraph
+
+**Structural analysis / CPG**
+- ast-grep: https://github.com/ast-grep/ast-grep (15.1k stars, MIT) · How it works(CodeRabbit 사례): https://ast-grep.github.io/advanced/how-ast-grep-works.html
+- Joern: https://docs.joern.io/code-property-graph/
+- Yamaguchi et al., CPG 원논문(IEEE S&P 2014): https://www.ieee-security.org/TC/SP2014/papers/ModelingandDiscoveringVulnerabilitieswithCodePropertyGraphs.pdf
+- LLMxCPG(USENIX Security 2025): https://arxiv.org/html/2507.16585v1
+- CodeQL dataflow: https://codeql.github.com/docs/writing-codeql-queries/about-data-flow-analysis/
+- Semgrep: https://github.com/semgrep/semgrep · Comby: https://comby.dev/
+
+**임베딩 vs AST (논증)**
+- Tabby(tree-sitter tags 명시): https://tabby.tabbyml.com/docs/welcome/
+- Greptile graph context: https://www.greptile.com/docs/how-greptile-works/graph-based-codebase-context · 임베딩 한계 자체 측정: https://www.greptile.com/blog/semantic-codebase-search
+- Reliable Graph-RAG(arXiv 2601.08773): https://arxiv.org/abs/2601.08773
+- Bloop(archived): https://github.com/BloopAI/bloop
+
+**선행 리서치 (본 문서와 직교)**
+- `2026-07-17-ast-context-research.md`(처방형 4단계 로드맵)
+- `2026-07-17-market-landscape.md`, `2026-07-17-engineering-concepts.md`

--- a/docs/superpowers/plans/2026-07-17-sprint-0a-ci-cd.md
+++ b/docs/superpowers/plans/2026-07-17-sprint-0a-ci-cd.md
@@ -1,0 +1,977 @@
+# Sprint 0a: CI/CD Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 영속적인 CI/CD 파이프라인 구축 — feature PR 게이트 + develop push 시 TestPyPI 자동 배포 + Docker 통합 테스트 + main merge 시 PyPI 정식 배포 및 GitHub Release 자동화.
+
+**Architecture:** `main + develop + feature/*` 3-티어 브랜치 정책. GitHub Actions 워크플로우 2종 (`ci.yml` PR 게이트, `release.yml` 배포 파이프라인). 기존 자산인 `scripts/build_testpypi_image.sh`와 `e2e/dockerfiles/testpypi/Dockerfile`을 Actions에서 호출해 재사용. 모든 workflow는 `actionlint`로 로컬 검증 후 push.
+
+**Tech Stack:** GitHub Actions, pytest, ruff, `python -m build`, twine, Docker, TestPyPI/PyPI, actionlint
+
+## Global Constraints
+
+- Python 3.10+ (pyproject.toml `requires-python = ">=3.10"`)
+- Apache-2.0 license
+- pytest config 위치: `pyproject.toml`의 `[tool.pytest.ini_options]`
+- 의존성 정의: `pyproject.toml`의 `[project.optional-dependencies]` (dev, e2e 그룹)
+- 모든 GitHub Actions workflow YAML은 push 전 `actionlint`로 검증
+- GitHub Secrets에 추가 필요: `TEST_PYPI_API_TOKEN`, `PYPI_API_TOKEN`
+- 기존 테스트 823개 통과가 회귀 베이스라인
+- 커밋 메시지: Conventional Commits (`feat:`, `chore:`, `ci:`, `docs:` 등)
+
+## File Structure
+
+**Create:**
+- `.github/workflows/ci.yml` — PR 게이트 (pytest, ruff, build, coverage)
+- `.github/workflows/release.yml` — TestPyPI(develop) + PyPI(main) 배포
+- `.github/branch-protection.yml` — 브랜치 보호 규칙 선언 (문서용)
+- `BRANCHING.md` — 브랜치 정책 문서
+- `scripts/validate-workflows.sh` — actionlint 실행 래퍼
+
+**Modify:**
+- `pyproject.toml` — pytest 플러그션 설정 수정 (`asyncio_mode`, `env` 등 Unknown config 해결)
+- `CONTRIBUTING.md` — feature/develop/main 워크플로우 추가
+- `.gitignore` — Python 캐시, coverage, build 산물 확장 (이미 대부분 있음, 검토만)
+
+**Test:**
+- `tests/test_pytest_config.py` (신규) — pytest config가 valid한지 검증
+- 각 workflow는 actionlint + dry-run(act)으로 검증
+
+---
+
+## Task 1: pytest 플러그인 설정 안정화
+
+**Why first:** selvage 점검에서 `pytest.ini_options`에 3개 Unknown config 경고가 있었음 (`asyncio_mode`, `env`, `asyncio_default_fixture_loop_scope`). 플러그인 누락이면 CI에서 비동기 테스트가 정상 동작 안 함. 이걸 먼저 잡아야 다음 task들의 CI가 안 터짐.
+
+**Files:**
+- Modify: `pyproject.toml` (pytest 설정 + optional-dependencies)
+- Test: `tests/test_pytest_config.py` (신규)
+
+**Interfaces:**
+- Consumes: 기존 `pyproject.toml`의 pytest 설정
+- Produces: `pytest tests/` 실행 시 Unknown config 경고 0건, 비동기 테스트 정상 동작
+
+- [ ] **Step 1: 현재 pytest 설정과 경고 확인**
+
+```bash
+cd /Users/demin_coder/Dev/selvage
+grep -A 20 '\[tool.pytest.ini_options\]' pyproject.toml
+pytest tests/ --collect-only 2>&1 | grep -i "unknown config"
+```
+
+Expected: `asyncio_mode`, `env`, `asyncio_default_fixture_loop_scope` 3개 경고.
+
+- [ ] **Step 2: 실패 테스트 작성**
+
+```python
+# tests/test_pytest_config.py
+"""pytest 설정이 valid한지 검증."""
+import configparser
+from pathlib import Path
+
+import pytest
+
+
+def test_pytest_config_no_unknown_options():
+    """pyproject.toml의 [tool.pytest.ini_options]가 모두 인식되는지 확인."""
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    assert pyproject.exists(), "pyproject.toml must exist"
+
+    # toml 파싱 (Python 3.11+ tomllib, 이전 버전은 tomli fallback)
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+
+    pytest_config = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+    assert pytest_config, "[tool.pytest.ini_options] must exist"
+
+    # Known pytest keys (https://docs.pytest.org/en/stable/reference/reference.html#ini-options-ref)
+    # 플러그인 키는 해당 플러그인 설치 시에만 인식됨
+    plugin_keys = {
+        "asyncio_mode": "pytest-asyncio",
+        "asyncio_default_fixture_loop_scope": "pytest-asyncio",
+        "env": "pytest-env",
+    }
+    installed_plugins = _get_installed_plugins()
+
+    for key, plugin in plugin_keys.items():
+        if key in pytest_config:
+            assert plugin in installed_plugins, (
+                f"'{key}' requires '{plugin}' but it's not installed. "
+                f"Add '{plugin}' to [project.optional-dependencies] dev."
+            )
+
+
+def _get_installed_plugins() -> set[str]:
+    """pip list에서 pytest-* 플러그인 추출."""
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["pip", "list", "--format=freeze"],
+            capture_output=True, text=True, check=True,
+        )
+        return {
+            line.split("==")[0].lower()
+            for line in result.stdout.splitlines()
+            if line.startswith("pytest-")
+        }
+    except Exception:
+        return set()
+```
+
+- [ ] **Step 3: 테스트 실행 (FAIL 예상)**
+
+```bash
+pytest tests/test_pytest_config.py -v
+```
+
+Expected: FAIL with `AssertionError: 'asyncio_mode' requires 'pytest-asyncio' but it's not installed`.
+
+- [ ] **Step 4: 플러그인을 dev 의존성에 추가**
+
+`pyproject.toml`의 `[project.optional-dependencies]`에서 `dev` 그룹에 추가:
+
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest==8.3.5",
+    "pytest-cov==6.0.0",
+    "pytest-asyncio==0.24.0",  # 추가
+    "pytest-env==1.1.3",        # 추가
+    "pytest-timeout==2.3.1",    # 이미 있을 수도, 확인
+    # ... 기존
+]
+```
+
+설치:
+
+```bash
+pip install -e ".[dev]"
+```
+
+- [ ] **Step 5: 테스트 재실행 (PASS 예상)**
+
+```bash
+pytest tests/test_pytest_config.py -v
+pytest tests/ --collect-only 2>&1 | grep -i "unknown config"
+```
+
+Expected: test PASS, Unknown config 경고 0건.
+
+- [ ] **Step 6: 전체 테스트 스위트 회귀 확인**
+
+```bash
+pytest tests/ --timeout=300 2>&1 | tail -10
+```
+
+Expected: `823 passed, 18 skipped` (또는 그 이상). 실패 시 해당 테스트 원인 조사 후 이 task에 step 추가.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add pyproject.toml tests/test_pytest_config.py
+git commit -m "fix: install missing pytest plugins (pytest-asyncio, pytest-env) to clear Unknown config warnings"
+```
+
+---
+
+## Task 2: develop 브랜치 + 브랜치 정책 문서
+
+**Files:**
+- Create: `BRANCHING.md`
+- Modify: `CONTRIBUTING.md` (브랜치 워크플로우 섹션 추가)
+
+**Interfaces:**
+- Consumes: 현재 main 브랜치
+- Produces: `origin/develop` 브랜치, 브랜치 정책 문서
+
+- [ ] **Step 1: develop 브랜치 생성 및 push**
+
+```bash
+cd /Users/demin_coder/Dev/selvage
+git checkout main
+git pull origin main
+git branch develop
+git push -u origin develop
+git checkout main
+```
+
+Expected: `origin/develop` 생성, 로컬 `develop` 브랜치 존재.
+
+- [ ] **Step 2: BRANCHING.md 작성**
+
+```markdown
+# Branching Policy
+
+selvage는 3-티어 브랜치 모델을 사용합니다.
+
+## 브랜치 구조
+
+| 브랜치 | 용도 | 권한 |
+|---|---|---|
+| `main` | 프로덕션 릴리스. tag `vX.Y.Z`로 PyPI 정식 배포 | 관리자만 머지 |
+| `develop` | Sprint 통합 지점. TestPyPI 자동 배포 | 관리자 + 핵심 기여자 |
+| `feature/*` | 개별 task 작업. PR → develop | 누구나 생성 |
+
+## 워크플로우
+
+1. **feature 브랜치 생성**
+   ```bash
+   git checkout develop
+   git pull origin develop
+   git checkout -b feature/sprint-N-<topic>
+   ```
+
+2. **작업 + 커밋** (Conventional Commits 준수)
+
+3. **PR 생성**: `feature/* → develop`
+   - CI 자동 실행 (pytest, ruff, build)
+   - 모두 통과 시 머지 가능
+
+4. **develop → main PR** (Sprint 종료 시)
+   - 관리자가 squash merge
+   - main push → PyPI 정식 배포 + tag + GitHub Release 자동
+
+## 네이밍 컨벤션
+
+- `feature/sprint-N-<topic>` — Sprint N의 개별 task (예: `feature/sprint-0a-ci-yaml`)
+- `fix/<topic>` — 버그 수정
+- `chore/<topic>` — 설정, 문서, 의존성
+- `release/vX.Y.Z` — 릴리스 준비 (필요 시)
+
+## 보호 규칙 (GitHub Settings)
+
+- `main`: PR required, status checks (CI) required, dismiss stale reviews
+- `develop`: PR required, status checks (CI) required
+- `feature/*`: 자유 (fork-equivalent)
+```
+
+- [ ] **Step 3: CONTRIBUTING.md에 브랜치 섹션 추가**
+
+`CONTRIBUTING.md`의 적절한 위치에 다음 섹션 삽입:
+
+```markdown
+## 브랜치 워크플로우
+
+[BRANCHING.md](./BRANCHING.md)를 참조하세요. 요약:
+
+1. `develop`에서 `feature/<topic>` 브랜치 생성
+2. 작업 후 PR → `develop` (CI 통과 필요)
+3. Sprint 종료 시 `develop` → `main` PR (관리자 먼지)
+```
+
+- [ ] **Step 4: 검증**
+
+```bash
+git branch -a | grep -E "(main|develop)"
+cat BRANCHING.md | head -20
+```
+
+Expected: `main`, `develop`, `origin/main`, `origin/develop` 모두 표시.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add BRANCHING.md CONTRIBUTING.md
+git commit -m "docs: add 3-tier branching policy (main + develop + feature/*)"
+git push origin develop
+```
+
+---
+
+## Task 3: actionlint 설치 + 워크플로우 검증 스크립트
+
+**Why:** workflow YAML을 push 전에 로컬 검증해야 CI 실패를 줄일 수 있음. 모든 workflow 변경 시 이 스크립트를 먼저 돌림.
+
+**Files:**
+- Create: `scripts/validate-workflows.sh`
+
+**Interfaces:**
+- Consumes: `.github/workflows/*.yml`
+- Produces: exit code 0 (valid) 또는 1 (invalid), stderr에 오류
+
+- [ ] **Step 1: actionlint 설치 확인 또는 설치**
+
+```bash
+which actionlint || brew install actionlint
+actionlint --version
+```
+
+Expected: 버전 출력. 설치 안 됐으면 `brew install actionlint`.
+
+- [ ] **Step 2: validate-workflows.sh 작성**
+
+```bash
+#!/usr/bin/env bash
+# Validate all GitHub Actions workflows with actionlint.
+# Run before pushing any workflow change: ./scripts/validate-workflows.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v actionlint >/dev/null 2>&1; then
+  echo "ERROR: actionlint not installed. Run: brew install actionlint" >&2
+  exit 1
+fi
+
+echo "Validating GitHub Actions workflows..."
+# shellcheck disable=SC2046
+if actionlint $(find .github/workflows -name '*.yml' -o -name '*.yaml'); then
+  echo "OK: all workflows valid"
+else
+  echo "FAIL: workflow validation failed (see errors above)" >&2
+  exit 1
+fi
+```
+
+- [ ] **Step 3: 실행 권한 + 테스트**
+
+```bash
+chmod +x scripts/validate-workflows.sh
+# 현재는 workflow 파일이 없으므로, 빈 디렉토리 케이스:
+ls .github/workflows/ 2>/dev/null || mkdir -p .github/workflows
+./scripts/validate-workflows.sh
+```
+
+Expected: `.github/workflows/`가 비어 있어도 OK이거나, actionlint가 "no files" 에러. 어느 쪽이든 Task 4에서 실제 workflow로 다시 테스트.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add scripts/validate-workflows.sh
+git commit -m "chore: add actionlint workflow validation script"
+```
+
+---
+
+## Task 4: CI 워크플로우 (ci.yml) — PR 게이트
+
+**Files:**
+- Create: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: pyproject.toml (의존성), tests/, ruff config
+- Produces: PR에서 pytest/ruff/build/coverage 실행. PR 상태 체크.
+
+- [ ] **Step 1: ci.yml 작성**
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Format check (ruff)
+        run: ruff format --check .
+
+      - name: Test with pytest
+        run: pytest tests/ --cov --cov-report=xml --cov-report=term-missing --timeout=300 -n auto
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.sha }}
+          path: dist/
+          retention-days: 7
+```
+
+- [ ] **Step 2: actionlint로 검증**
+
+```bash
+./scripts/validate-workflows.sh
+```
+
+Expected: `OK: all workflows valid`. 실패 시 에러 읽고 수정.
+
+- [ ] **Step 3: feature 브랜치에서 PR 생성**
+
+```bash
+git checkout -b feature/sprint-0a-ci-workflow develop
+git add .github/workflows/ci.yml
+git commit -m "ci: add PR gate workflow (pytest, ruff, build, coverage) on Python 3.10-3.13 matrix"
+git push -u origin feature/sprint-0a-ci-workflow
+gh pr create --base develop --title "ci: add CI workflow (Sprint 0a Task 4)" --body "PR gate for pytest/ruff/build/coverage. Matrix Python 3.10-3.13."
+```
+
+- [ ] **Step 4: GitHub Actions 탭에서 워크플로우 실행 확인**
+
+```bash
+gh run watch
+```
+
+Expected: `test (3.10)`, `test (3.11)`, ..., `build` 모두 green. 실패 시 로그 읽고 수정 후 추가 커밋.
+
+- [ ] **Step 5: PR 승인 + develop로 머지**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout develop
+git pull origin develop
+```
+
+---
+
+## Task 5: TestPyPI 자동 배포 (release.yml part 1)
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+- Modify: `scripts/build_testpypi_image.sh` (Actions 호환성 점검)
+
+**Interfaces:**
+- Consumes: GitHub Secret `TEST_PYPI_API_TOKEN`, 기존 `scripts/build_testpypi_image.sh`
+- Produces: `develop` push 시 TestPyPI로 selvage 패키지 자동 업로드
+
+- [ ] **Step 1: TestPyPI 계정 + API token 확인**
+
+```bash
+# https://test.pypi.org/manage/account/token/ 에서 token 발급
+# GitHub repo Settings → Secrets and variables → Actions → New repository secret:
+#   Name: TEST_PYPI_API_TOKEN
+#   Value: pypi-YYYY...
+gh secret list | grep TEST_PYPI_API_TOKEN
+```
+
+Expected: `TEST_PYPI_API_TOKEN` 표시. 없으면 사용자가 수동 추가 필요.
+
+- [ ] **Step 2: build_testpypi_image.sh Actions 호환성 점검**
+
+```bash
+cat scripts/build_testpypi_image.sh
+# 스크립트가 절대 경로 / 하드코딩 없이 상대 경로로 동작하는지 확인
+# 필요 시 수정 (CWD 기반으로)
+```
+
+수정 필요 시 예:
+
+```bash
+#!/usr/bin/env bash
+# scripts/build_testpypi_image.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+VERSION=$(python -c "from selvage.__version__ import __version__; print(__version__)")
+TAG="selvage-testpypi:${VERSION}"
+LATEST_TAG="selvage-testpypi:latest"
+
+echo "Building ${TAG}..."
+docker build \
+  --build-arg SELVAGE_VERSION="${VERSION}" \
+  -t "${TAG}" -t "${LATEST_TAG}" \
+  -f e2e/dockerfiles/testpypi/Dockerfile \
+  .
+
+echo "Built ${TAG} and ${LATEST_TAG}"
+```
+
+- [ ] **Step 3: release.yml 작성 (TestPyPI 잡만 우선)**
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    branches: [develop, main]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Override target (testpypi or pypi)'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - ''
+          - testpypi
+          - pypi
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(python -c "from selvage.__version__ import __version__; print(__version__)")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building version ${VERSION}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.ref == 'refs/heads/develop' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi')
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+        run: |
+          pip install --upgrade twine
+          twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+      - name: Wait for TestPyPI propagation
+        run: sleep 30
+
+      - name: Build and test Docker image
+        run: |
+          pip install -e ".[e2e]"
+          ./scripts/build_testpypi_image.sh
+
+      - name: Run e2e tests against TestPyPI image
+        run: |
+          docker run --rm \
+            -e OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" \
+            -e ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
+            selvage-testpypi:latest \
+            pytest e2e/ --timeout=600 -v
+```
+
+- [ ] **Step 4: actionlint 검증**
+
+```bash
+./scripts/validate-workflows.sh
+```
+
+- [ ] **Step 5: feature 브랜치에서 PR**
+
+```bash
+git checkout -b feature/sprint-0a-testpypi-release develop
+git add .github/workflows/release.yml scripts/build_testpypi_image.sh
+git commit -m "ci: add TestPyPI auto-release on develop push with Docker e2e validation"
+git push -u origin feature/sprint-0a-testpypi-release
+gh pr create --base develop --title "ci: TestPyPI auto-release (Sprint 0a Task 5)" --body "..."
+```
+
+- [ ] **Step 6: develop 머지 후 TestPyPI 자동 배포 확인**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout develop && git pull origin develop
+gh run watch
+```
+
+Expected: `build` → `testpypi` job green. TestPyPI(https://test.pypi.org/project/selvage/)에서 현재 버전 확인. Docker `selvage-testpypi:latest` 빌드 로그 확인. e2e 테스트 통과.
+
+---
+
+## Task 6: PyPI 정식 배포 + tag + GitHub Release
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (pypi 잡 추가)
+
+**Interfaces:**
+- Consumes: GitHub Secret `PYPI_API_TOKEN`, 이전 `build` 잡의 artifacts
+- Produces: `main` merge 시 PyPI 정식 업로드 + git tag `vX.Y.Z` + GitHub Release
+
+- [ ] **Step 1: PyPI API token 확인**
+
+```bash
+# https://pypi.org/manage/account/token/에서 발급 (별도 token 권장)
+gh secret list | grep PYPI_API_TOKEN
+```
+
+없으면 사용자 수동 추가.
+
+- [ ] **Step 2: release.yml에 pypi 잡 추가**
+
+`release.yml`의 `testpypi` 잡 뒤에 `pypi` 잡 추가:
+
+```yaml
+  pypi:
+    name: Publish to PyPI + tag + GitHub Release
+    needs: build
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+        run: |
+          pip install --upgrade twine
+          twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+
+      - name: Create git tag
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          # CHANGELOG.md에서 vX.Y.Z 섹션 추출
+          python scripts/extract_changelog.py "${VERSION}" > release_notes.md || echo "Release v${VERSION}" > release_notes.md
+          cat release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.build.outputs.version }}
+          body_path: release_notes.md
+          files: dist/*
+          draft: false
+          prerelease: ${{ contains(needs.build.outputs.version, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- [ ] **Step 3: extract_changelog.py 작성**
+
+```python
+# scripts/extract_changelog.py
+"""CHANGELOG.md에서 특정 버전 섹션을 추출.
+
+Usage: python scripts/extract_changelog.py 0.4.2
+"""
+import re
+import sys
+from pathlib import Path
+
+
+def extract(version: str) -> str:
+    changelog = Path(__file__).parent.parent / "CHANGELOG.md"
+    if not changelog.exists():
+        return f"Release v{version}"
+
+    content = changelog.read_text(encoding="utf-8")
+    # ## [0.4.2] - 2026-07-17 형식 또는 ## v0.4.2 형식 매칭
+    pattern = rf"##\s*\[?v?{re.escape(version)}\]?(.*?)(?=^##\s|\Z)"
+    match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
+    if not match:
+        return f"Release v{version}"
+    return match.group(1).strip()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: extract_changelog.py <version>", file=sys.stderr)
+        sys.exit(1)
+    print(extract(sys.argv[1]))
+```
+
+- [ ] **Step 4: actionlint 검증 + PR**
+
+```bash
+./scripts/validate-workflows.sh
+git checkout -b feature/sprint-0a-pypi-release develop
+git add .github/workflows/release.yml scripts/extract_changelog.py
+git commit -m "ci: add PyPI production release + tag + GitHub Release on main merge"
+git push -u origin feature/sprint-0a-pypi-release
+gh pr create --base develop --title "ci: PyPI production release (Sprint 0a Task 6)" --body "..."
+```
+
+- [ ] **Step 5: develop → main PR + 릴리스 검증**
+
+```bash
+gh pr merge --squash --delete-branch  # develop로 먼지
+git checkout develop && git pull
+git checkout main && git pull
+# Sprint 0a 종료 시 develop → main PR:
+gh pr create --base main --head develop --title "release: v0.4.2 — Reactivation Sprint 0a" --body "..."
+gh pr merge --squash
+gh run watch
+```
+
+Expected: `main` push → `build` → `pypi` job green. PyPI(https://pypi.org/project/selvage/)에 새 버전 표시. git tag `v0.4.2` push됨. GitHub Release 생성됨.
+
+---
+
+## Task 7: CHANGELOG 자동화 (commitizen)
+
+**Files:**
+- Modify: `pyproject.toml` (commitizen 설정)
+- Modify: `CHANGELOG.md` (포맷 표준화)
+- Create: `scripts/bump-version.sh`
+
+**Interfaces:**
+- Consumes: conventional commits 히스토리
+- Produces: `cz bump` 실행 시 semantic versioning + CHANGELOG 자동 갱신
+
+- [ ] **Step 1: commitizen을 dev 의존성에 추가**
+
+`pyproject.toml`에 추가:
+
+```toml
+[project.optional-dependencies]
+dev = [
+    # ... 기존
+    "commitizen==4.1.0",
+]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.4.1"
+version_files = [
+    "selvage/__version__.py:__version__",
+    "pyproject.toml:version",
+]
+tag_format = "v$version"
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"
+changelog_incremental = true
+annotated_tag = true
+```
+
+- [ ] **Step 2: bump-version.sh 작성**
+
+```bash
+#!/usr/bin/env bash
+# Semantic version bump + CHANGELOG update.
+# Usage: ./scripts/bump-version.sh [major|minor|patch]
+# Default: patch (no args → commitizen이 changelog 기반 결정)
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+BUMP="${1:-}"
+ARGS=()
+if [ -n "$BUMP" ]; then
+  ARGS+=("--increment" "$BUMP")
+fi
+
+# commitizen이 버전 결정 + CHANGELOG 갱신 + 커밋 + 태그
+cz bump "${ARGS[@]}"
+
+# push
+git push --follow-tags origin "$(git rev-parse --abbrev-ref HEAD)"
+```
+
+- [ ] **Step 3: CHANGELOG.md 포맷 점검**
+
+```bash
+head -30 CHANGELOG.md
+```
+
+`## [0.4.2] - YYYY-MM-DD` 형식인지 확인. 아니면 포맷 조정 (commitizen 호환).
+
+- [ ] **Step 4: 테스트 bump (dry-run)**
+
+```bash
+pip install -e ".[dev]"
+cz version --dry-run --patch  # 또는 cz bump --dry-run
+./scripts/bump-version.sh --dry-run
+```
+
+Expected: 다음 버전 표시 (0.4.1 → 0.4.2). 실제 커밋은 안 함.
+
+- [ ] **Step 5: PR**
+
+```bash
+git checkout -b feature/sprint-0a-commitizen develop
+git add pyproject.toml scripts/bump-version.sh CHANGELOG.md
+git commit -m "chore: add commitizen for semantic versioning and changelog automation"
+git push -u origin feature/sprint-0a-commitizen
+gh pr create --base develop --title "chore: commitizen integration (Sprint 0a Task 7)" --body "..."
+```
+
+- [ ] **Step 6: develop 머지 후 dry-run으로 동작 확인**
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout develop && git pull
+cz changelog --dry-run
+```
+
+Expected: CHANGELOG에 반영될 변경 사항 요약 출력.
+
+---
+
+## Self-Review
+
+### 1. Spec coverage (마스터 플랜 v1.1 Sprint 0a 체크리스트)
+
+체크리스트 14개 항목 → task 매핑:
+
+- [x] develop 브랜치 존재, main과 동기화 → Task 2 Step 1
+- [x] feature/* 브랜치 정책 문서화 → Task 2 Step 2 (BRANCHING.md)
+- [x] ci.yml 존재 → Task 4 Step 1
+- [x] ci.yml이 feature PR에서 pytest 실행 → Task 4 (matrix Python 3.10-3.13)
+- [x] ruff check 실행 → Task 4 ci.yml `Lint (ruff)` step
+- [x] python -m build 실행 → Task 4 `build` job
+- [x] coverage 보고 → Task 4 `--cov-report` + codecov
+- [x] release.yml 존재 → Task 5 Step 3
+- [x] develop push 시 TestPyPI 업로드 → Task 5 `testpypi` job
+- [x] build_testpypi_image.sh Actions 호출 → Task 5 `Build and test Docker image` step
+- [x] selvage-testpypi:latest Docker 빌드 → Task 5 (스크립트가 태깅)
+- [x] e2e 통합 테스트 Docker 실행 → Task 5 `Run e2e tests` step
+- [x] main merge 시 PyPI + tag + Release 자동화 → Task 6 `pypi` job
+- [x] pytest tests/ 0 failure → Task 1 Step 6
+
+14/14 covered.
+
+### 2. Placeholder scan
+
+- "TBD", "TODO", "implement later" → 없음
+- "Add appropriate error handling" → 없음. 모든 step에 실제 코드 포함.
+- "Similar to Task N" → 없음. 코드 반복.
+
+### 3. Type consistency
+
+- `version` output (Task 5 build job) → Task 6 pypi job에서 `needs.build.outputs.version`로 사용. 일치.
+- `TEST_PYPI_API_TOKEN`, `PYPI_API_TOKEN` — 일관된 이름 사용.
+- `dist/` artifact — build job에서 upload, testpypi/pypi job에서 download. 일치.
+
+### 4. 추가 발견
+
+- Task 5의 Docker e2e는 GitHub Actions runner에 Docker 기본 설치를 가정. ubuntu-latest는 OK.
+- Task 6의 `softprops/action-gh-release@v2`는 GITHUB_TOKEN으로 release 생성. 별도 token 불필요.
+- 모든 workflow에 `concurrency` 그룹으로 중복 실행 방지.
+- `permissions: contents: write, id-token: write`는 tag/release에 필요.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-07-17-sprint-0a-ci-cd.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — 각 task마다 codex/claude 하위 에이전트 디스패치 (orca worktree), task 사이에 검증. 빠른 iteration. 특히 Task 4-6 (workflow YAML)은 독립적이라 병렬 가능.
+
+**2. Inline Execution** — 현재 세션에서 executing-plans 스킬로 순차 실행. checkpoint마다 사용자 리뷰.
+
+**권장**: Subagent-Driven + 병렬 디스패치. 단, Task 1(pytest 안정화)과 Task 2(develop 브랜치)는 선행 직렬. Task 3-7은 feature 브랜치로 병렬 가능.
+
+**다음 단계**: 어느 execution 옵션으로 갈지 결정 후, Task 1부터 시작. 단, 이 plan은 Sprint 1 AST 리서치(claude 하위 에이전트 백그라운드 실행 중)와 독립적이라 병렬 진행 가능.

--- a/docs/superpowers/plans/sprint-0c-eval-infra.md
+++ b/docs/superpowers/plans/sprint-0c-eval-infra.md
@@ -1,0 +1,368 @@
+# Sprint 0c — 자체 경량 Eval 인프라 재구축 계획
+
+> 기준일: 2026-07-17 · 대상: `selvage` 리포 · 상태: 설계 제안
+
+## 1. Executive summary
+
+방치된 `llm_eval/`과 별도 `selvage-eval-agent`를 폐기·흡수하고, `ReviewRun` manifest와 Pydantic golden fixture를 중심으로 한 결정론적 eval을 `selvage`에 구축한다. PR에서는 저장된 run을 재생해 finding precision/recall, 오탐, severity, caller/wrong-def 회귀를 차단하고 결과를 코멘트한다. 실제 LLM 호출과 LLM-as-judge는 비차단·선택 경로로 격리한다.
+
+## 2. 현재 `selvage/llm_eval/` 진단
+
+### 2.1 구조와 동작 상태
+
+| 자산 | 실제 상태 | 판단 |
+|---|---|---|
+| `README_DEEPEVAL.md` | Python 3.13.2 및 DeepEval 설치/CLI 사용법만 설명 | 역사 참고 후 제거 |
+| `test_deepeval_hello_world.py` | 일반 질의용 2개 테스트가 모두 `@pytest.mark.skip` | 제품 eval로 재사용 불가 |
+| `test_deepeval_advanced.py` | mock 응답용 2개 테스트가 모두 skip | 제품 eval로 재사용 불가 |
+| `test_reviewer_eval.py` | import 시 GEval 3종과 JSON metric을 생성하고 JSON 1개를 parameterize | 평가 관점만 참고 |
+| `data_set/*.json` | 11개 DeepEval 입력/출력 snapshot | golden 후보 탐색용 원자료 |
+| `pytest.ini` | `env`, `timeout=900`, `--maxfail=1` 설정 | 루트 pytest 설정으로 통합 |
+
+2026-07-17에 60초 외부 timeout으로 실행했다. 기본 `uv` 환경에는 DeepEval이 없으며, DeepEval 3.3.9가 있는 기존 eval-agent venv와 현재 리포 의존성을 조합한 최종 실행은 **4개 수집 후 1개 collection error**로 종료했다. `test_reviewer_eval.py:50`에서 `GEval(model="gemini-2.5-pro")`를 import 시 생성하지만 해당 DeepEval 버전은 이를 GPT 모델로 해석해 “Invalid model”을 발생시킨다. 테스트 본문은 실행되지 않았다. `pytest.ini`의 `env`와 `timeout`도 대응 플러그인이 없어 경고가 났다. 즉 현재 디렉터리는 CI에서 독립 실행할 수 없다.
+
+실제 평가 기준에는 보존 가치가 있다. 예를 들어 다음은 completeness, 위치, 유형, severity, 사실성이라는 finding 축을 이미 표현한다.
+
+```python
+# llm_eval/test_reviewer_eval.py:53-63
+evaluation_steps=[
+    "Verify that all pertinent issues ... are reported in the 'issues' array.",
+    "If issues are reported, check if their specified filenames and line numbers are accurate.",
+    "If issues are reported, confirm if their severity levels ... are assigned ...",
+]
+```
+
+다만 이 문장을 judge prompt로 그대로 이식하지 않고, 아래의 golden 필드와 deterministic metric으로 분해한다. `JsonCorrectnessMetric`도 버리고 `ReviewRun.model_validate_json()`으로 대체한다.
+
+### 2.2 현재 제품 코드와 통합 지점
+
+실행 경로는 `cli.review()` → `review_code()` → `ReviewRequest` → `PromptGenerator` → `GatewayFactory`/`BaseGateway.review_code()` → `ReviewResponse` → `ReviewLogManager.save()`이다.
+
+```python
+# selvage/cli.py:451-467
+diff_content = get_diff_content(repo_path, staged, target_commit, target_branch)
+diff_result = parse_git_diff(diff_content, repo_path)
+review_request = ReviewRequest(
+    diff_content=diff_content, processed_diff=diff_result,
+    file_paths=[file.filename for file in diff_result.files],
+    model=model, repo_path=repo_path,
+)
+```
+
+`PromptGenerator`는 `VERSION = "v4"`이고, 파일별 smart/fallback/full context를 선택해 `ReviewPromptWithFileContent`를 만든다(`selvage/src/utils/prompts/prompt_generator.py:24-27, 100-162`). `BaseGateway`는 이를 messages로 바꾸고 provider별 호출 후 `StructuredReviewResponse`를 검증하며 비용을 계산한다(`base_gateway.py:185-195, 231-256`). 결과 모델은 이미 `ReviewIssue(file, line_number, type, severity, target_code, ...)`와 `ReviewResponse`를 제공한다(`token/models.py:77-136`).
+
+가장 가까운 manifest 전신은 review log다.
+
+```python
+# selvage/src/utils/logging/review_log_manager.py:77-96
+review_log = {
+    "id": log_id, "model": {"provider": provider.value, "name": model_name},
+    "created_at": now.isoformat(), "prompt": prompt_data,
+    "review_request": review_request.model_dump(mode="json"),
+    "review_response": response_data, "prompt_version": "v4",
+}
+```
+
+여기에 없는 diff digest/snapshot 경계, skill version, 실제 context chunks, tool calls, 시간·토큰 budget, 종료 상태를 Sprint 2 `ReviewRun`으로 승격한다. Sprint 0c에서는 스키마와 serializer protocol을 먼저 고정하고, `ReviewLogManager.save()`에는 임시 adapter를 둔다. CLI와 gateway가 eval을 직접 알게 하지 말고 `RunRecorder` protocol을 주입해 단계별 event를 기록한다. 이 경계는 normal/multiturn/cache 경로를 모두 동일 manifest로 관찰하게 한다.
+
+## 3. `selvage-eval-agent` 마이그레이션 자산
+
+| 원본 파일/디렉터리 | 가져올 내용 | 목적지/처리 |
+|---|---|---|
+| `configs/selvage-eval-config.yml` | cline, fastapi, ecommerce-microservices, ktor, aider의 기술 스택과 readonly 의도; 모델 목록 | `eval/config/repositories.yml`; 절대 경로·구형 모델명·binary path 제거, URL+commit SHA로 고정 |
+| `src/selvage_eval/config/commit-collection-config.yml` | XS/S/M/L/XL 기준(10/100/500/9999), 비율(15/50/20/13/2), 최소 품질/재분배 정책 | `eval/config/commit-selection.yml`; 근거와 버전을 명시 |
+| `commit_collection/{commit_stats,commit_data,commit_score,commit_size_category,diversity_selector}.py` | 변경량 모델, 경계값, 크기별 quota와 deterministic quality sort | `selvage/src/eval/collection/`; dataclass를 Pydantic으로 정리 |
+| `commit_collection/commit_collector.py` | non-code 감점, positive/negative keyword, core/config path 분류 | 휴리스틱만 포팅; shell 문자열 조립과 checkout은 제외 |
+| `tests/commit_collection/test_commit_collection.py` | git numstat 파싱, 필터·점수·직렬화 케이스 | 새 collection 단위 테스트로 축약 이식 |
+| `tests/commit_collection/test_commit_size_category.py`, `test_diversity_selector.py` | 경계값, 파일 수 보정, quota/shortage/quality 검증 | 거의 그대로 포팅할 최우선 테스트 |
+| `sample/*.json` 3개 | 동일 시점 Gemini Flash/Pro, Claude review log 구조 | golden 저작 시 비교 샘플; 정답으로 자동 승격 금지 |
+| `sample/deepEval/*.json` | 기존 input/actual output | 후보 finding 수동 라벨링 후 새 fixture로 변환 |
+| `tools/review_executor_tool.py` 및 관련 tests | commit×model 실행 행렬, 성공/실패 summary, 원 브랜치 복구 의도 | subprocess 구현은 폐기; `git show SHA^!` 기반 read-only runner와 summary test만 재작성 |
+| `analysis/metric_aggregator.py`, `version_comparison_analyzer.py` 및 tests | 모델/버전별 집계, regression trend, 빈 입력 처리 | NumPy/DeepEval 타입 제거 후 표준 라이브러리 집계로 포팅 |
+| `analysis/tech_stack_analyzer.py` | repository→tech stack grouping | deterministic 결과 grouping만 포팅 |
+| DeepEval executor/parser/engine, ReAct agent, Gemini failure analyzer | DeepEval·외부 judge·에이전트 결합 | 이식하지 않음 |
+
+사용자가 언급한 142개와 달리 현재 `selvage-eval-results/` 실파일은 **137개, 984KB**다(67 session metadata + 67 session state + `session_state.json`, `meaningful_commits.json`, `file_change_commit2.json`; 2025-07-02~2025-11-17). 숫자 차이를 migration record에 남긴다. 대부분 실행 제어 상태라 golden은 아니다. `docs/historical-evals/index.md`에 원본 commit, 파일 수, SHA-256, 기간, 스키마, 알려진 결손을 기록하고, 원본 JSON은 `docs/historical-evals/archive/`에 읽기 전용으로 보존하되 PR metric 입력에서는 제외한다. 개인정보·로컬 절대 경로를 검사/마스킹한 뒤 이동하며 3개 sample log도 동일 정책을 적용한다.
+
+## 4. 자체 경량 eval 설계
+
+### 4.1 디렉터리 구조
+
+```text
+selvage/src/eval/
+  models.py          # ReviewRun, GoldenFixture, DiffSource, EvalReport
+  recorder.py        # RunRecorder protocol / JSONL event recorder
+  extractor.py       # ReviewResponse -> normalized Finding
+  matcher.py         # deterministic bipartite matching
+  metrics.py         # 순수 함수
+  runner.py          # replay/live orchestration
+  diff_fetcher.py    # synthetic inline or external git clone
+  collection/        # 선별 로직
+eval/
+  config/{repositories,commit-selection,thresholds}.yml
+  fixtures/
+    synthetic/<stack>/<case-id>.yml     # inline_patch 포함 (selvage 저작물)
+    external/<stack>/<case-id>.yml      # repo_url+commit_sha+diff_range만 (코드 저장 X)
+  manifests/replay/*.json
+tests/eval/{test_models,test_matcher,test_metrics,test_replay,test_diff_fetcher}.py
+docs/historical-evals/{index.md,archive/}   # 별도 리포 또는 submodule 권장
+```
+
+**fixture 정책 (라이센스 회피)**:
+- **synthetic**: selvage 팀이 직접 작성한 작은 테스트 케이스. inline_patch 필드에 diff 텍스트 저장. selvage Apache 2.0 저작물. 라이센스 이슈 0.
+- **external**: 외부 OSS repo의 diff를 평가. **코드 자체는 저장하지 않고** `repo_url + commit_sha + diff_range + license_attribution` 메타데이터만 저장. runtime에 `git clone → checkout → diff` 추출. 외부 코드를 한 줄도 복제/재배포하지 않으므로 라이센스 이슈 0.
+
+### 4.2 Sprint 2 선행 인터페이스
+
+```python
+from datetime import datetime
+from enum import Enum
+from pydantic import BaseModel, ConfigDict, Field
+
+class VersionRef(BaseModel):
+    name: str
+    version: str
+    digest: str | None = None
+
+class DiffSnapshot(BaseModel):
+    base_sha: str
+    head_sha: str
+    patch: str
+    sha256: str
+    files: list[str]
+
+class ContextChunk(BaseModel):
+    chunk_id: str
+    file: str
+    start_line: int | None = None
+    end_line: int | None = None
+    content_sha256: str
+    text: str | None = None       # 공개 fixture만 inline
+    strategy: str                 # smart|fallback|full|tool
+
+class ToolCall(BaseModel):
+    call_id: str
+    name: str
+    arguments: dict
+    result_sha256: str | None = None
+    status: str
+    duration_ms: int
+
+class Budget(BaseModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    max_context_tokens: int | None = None
+    cost_usd: float = 0
+    wall_time_ms: int = 0
+
+class Finding(BaseModel):
+    finding_id: str
+    file: str
+    start_line: int | None = None
+    end_line: int | None = None
+    category: str
+    severity: str
+    title: str
+    description: str
+    target_symbol: str | None = None
+    evidence: list[str] = Field(default_factory=list)
+
+class ReviewRun(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: str = "review-run/v1"
+    run_id: str
+    created_at: datetime
+    source: dict                # repo, commit, trigger, selvage_version
+    diff: DiffSnapshot
+    model: VersionRef
+    prompt: VersionRef
+    skills: list[VersionRef] = Field(default_factory=list)
+    context_chunks: list[ContextChunk] = Field(default_factory=list)
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    budgets: Budget
+    findings: list[Finding] = Field(default_factory=list)
+    status: str                 # success|failed|partial|cached
+    error: str | None = None
+```
+
+`schema_version`은 payload 호환성, 각 digest는 재현성을 담당한다. timestamp/run_id는 비교 전에 제외하며 목록은 `finding_id`, `chunk_id`, `call_id`로 정렬한다. patch와 공개 context만 inline하고 민감한 live context는 digest+artifact reference 정책을 쓴다.
+
+### 4.3 Golden fixture와 비교
+
+**DiffSource** (라이센스 이슈 회피 핵심): synthetic은 inline 패치 저장, external은 메타데이터만 저장하고 runtime에 clone.
+
+```python
+class DiffSource(BaseModel):
+    """두 가지 방식: synthetic inline 또는 external runtime-clone.
+    외부 OSS 코드는 저장하지 않는다 (라이센스 이슈 0)."""
+    model_config = ConfigDict(extra="forbid")
+    kind: str  # "synthetic" | "external"
+    # synthetic인 경우 (selvage 저작물, inline OK)
+    inline_patch: str | None = None
+    # external인 경우 (외부 OSS repo, 코드 저장 X)
+    repo_url: str | None = None
+    commit_sha: str | None = None
+    diff_range: str | None = None  # "base..head" 형식
+    license_attribution: str | None = None  # "© Author, MIT License"
+    license_kind: str | None = None  # "MIT" | "Apache-2.0" | "BSD-3-Clause" | ... (permissive만 허용)
+```
+
+```python
+class Location(BaseModel):
+    file: str
+    start_line: int | None = None
+    end_line: int | None = None
+    symbol: str | None = None
+
+class ExpectedFinding(BaseModel):
+    id: str
+    locations: list[Location]
+    categories: set[str]
+    severity: str
+    aliases: set[str] = Field(default_factory=set)
+    required: bool = True
+    tags: set[str] = Field(default_factory=set)  # caller, wrong-def 등
+
+class NegativeExpectation(BaseModel):
+    id: str
+    location: Location | None = None
+    forbidden_categories: set[str] = Field(default_factory=set)
+
+class GoldenFixture(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: str = "golden/v1"
+    case_id: str
+    diff_source: DiffSource          # ★ 변경: diff_file 대신 DiffSource
+    diff_sha256: str                 # synthetic은 inline_patch hash, external은 runtime 추출 diff hash
+    stack: str
+    expected: list[ExpectedFinding]
+    negatives: list[NegativeExpectation] = Field(default_factory=list)
+    thresholds: dict[str, float]
+    provenance: dict                 # source SHA, labelers, reviewed_at
+```
+
+**DiffSource 검증 규칙** (런타임 + CI):
+- `kind="synthetic"`: `inline_patch` 필수. `repo_url/commit_sha` 금지.
+- `kind="external"`: `repo_url/commit_sha/diff_range/license_attribution/license_kind` 필수. `inline_patch` 금지.
+- `license_kind` 화이트리스트: `MIT`, `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MPL-2.0` (permissive만). **GPL/LGPL/AGPL/상용 금지** — 라이센스 전염/침해 리스크.
+- 모든 external fixture는 CONTRIBUTING.md에 "이 리포는 외부 OSS 코드를 저장하지 않는다" 명시.
+
+추출기는 기존 `ReviewResponse.issues`를 경로 POSIX화, severity enum화, line range화하고 텍스트 공백만 정규화한다. matcher는 `(정규화 경로 일치) AND (line range 교차 또는 symbol 일치) AND (category/alias 일치)` 후보만 만들고, 점수 `(location 0~2, category 0~1, severity 0~1)` 내림차순 뒤 `(expected.id, finding_id)`로 tie-break하는 one-to-one greedy matching을 사용한다. 임베딩·fuzzy 의미 비교는 금지한다. line 이동은 fixture에 허용 range로 명시한다.
+
+| Metric | 정의 | PR 기본 gate |
+|---|---|---|
+| precision | `TP / (TP + FP)`; 예측 0이면 1.0 | 전체 ≥ 0.80 |
+| recall | `TP / (TP + FN)`; 필수 expected 0이면 1.0 | 전체 ≥ 0.80, case별 하한 별도 |
+| false positive rate | negative assertion 단위 `violated / total negatives` | ≤ 0.10; negatives 0이면 N/A |
+| severity calibration | 매칭쌍의 `abs(rank(pred)-rank(gold))/2` 평균(error/warning/info) | error ≤ 0.25 |
+| caller recall | `caller` tag가 붙은 필수 finding의 recall | Sprint 1 baseline 대비 하락 0, 절대 ≥ 0.85 |
+| wrong-def rate | `wrong-def` negative 위반 수 / `wrong-def` 검사 수 | Sprint 1 baseline 이하, 목표 ≤ 0.05 |
+
+보고서는 micro/macro 값을 함께 내며 0분모 정책과 N/A를 숨기지 않는다. fixture 변경은 코드 변경과 분리하고 labeler 2인 승인 또는 명시적 owner 승인을 요구한다.
+
+### 4.4 선택적 LLM-as-judge
+
+결정론적 matcher가 `unmatched`이면서 위치·category 후보는 있는 모호한 건만 judge queue에 보낸다. provider SDK를 직접 사용하되 `JudgeProtocol.evaluate(case, expected, actual) -> JudgeVerdict`로 격리하고 prompt/model/digest, 원문, 비용을 별도 manifest에 기록한다. temperature 0, 구조화 출력, 최대 1회 호출, 결과는 PR 차단 점수에 섞지 않는다. 사람이 승인한 verdict만 alias/range 개선 제안이 되며 golden을 자동 수정하지 않는다. nightly/manual workflow에서만 secret을 허용한다.
+
+## 5. 단계별 구현 로드맵
+
+| Phase | 작업 | 완료 조건 |
+|---|---|---|
+| A — 진단 정리 | 기존 `llm_eval` quarantine, 137개 archive inventory/hash/PII 검사, 이식 ADR | DeepEval import가 제품/CI 의존성에 0건 |
+| B — 데이터 모델 | 위 Pydantic 모델, JSON Schema export, `ReviewLog` adapter, recorder protocol | round-trip·extra forbid·v1 fixture tests 통과 |
+| C — 평가 로직 | normalize/extract/match/metric/report CLI 구현 | 순수 단위 테스트와 동일 입력 byte-identical report |
+| D — golden 구축 | 언어/크기/clean-negative 층화, 기존 11 dataset·3 sample 수동 라벨링 | 최소 20 case, stack별·caller/wrong-def coverage 표 공개 |
+| E — CI 통합 | replay gate, artifact, sticky PR comment; live/judge 별도 | fork PR secret 없이 동작, 실패 시 metric delta 표시 |
+
+## 6. CI 통합 방안
+
+PR 필수 job은 LLM을 호출하지 않고 versioned replay manifest 또는 test double 결과를 fixture와 비교한다. prompt/gateway 변경 PR은 replay fixture 호환성까지 검증하고, 실제 모델 품질 drift는 schedule/manual job이 관찰한다.
+
+```yaml
+name: eval-regression
+on:
+  pull_request:
+    paths: ["selvage/**", "eval/**", "tests/eval/**", "pyproject.toml", "uv.lock"]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  deterministic-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --locked --extra dev
+      - run: uv run pytest tests/eval -q
+      - run: uv run python -m selvage.src.eval.runner replay --fixtures eval/fixtures --runs eval/manifests/replay --report eval-report.md --json eval-report.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: {name: eval-report, path: "eval-report.*"}
+      - uses: actions/github-script@v7
+        if: always() && github.event.pull_request.head.repo.fork == false
+        with:
+          script: |
+            const fs = require('fs');
+            const body = '<!-- selvage-eval -->\n' + fs.readFileSync('eval-report.md', 'utf8');
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {owner, repo, issue_number});
+            const old = comments.find(c => c.body?.includes('<!-- selvage-eval -->'));
+            old ? await github.rest.issues.updateComment({owner, repo, comment_id: old.id, body})
+                : await github.rest.issues.createComment({owner, repo, issue_number, body});
+```
+
+fork PR에서는 write token이 없으므로 코멘트를 생략하고 job summary/artifact만 제공한다. `pull_request_target`에서 PR 코드를 실행하지 않는다. report 생성은 metric gate 실패 전에도 완료되도록 runner가 JSON/Markdown을 쓰고 비정상 exit code를 마지막에 반환한다.
+
+## 7. 리스크와 제약
+
+| 리스크 | 영향 | 대응 |
+|---|---|---|
+| LLM 비결정성과 replay의 차이 | PR gate가 실제 품질을 완전히 대변하지 않음 | PR은 코드 결정성, nightly는 drift로 역할 분리 |
+| golden label 오류/과적합 | metric 신뢰도 저하 | provenance, 2인 검토, stack/size 층화, fixture 변경 분리 |
+| line number 취약성 | 같은 finding이 FN 처리 | range/symbol을 fixture에 명시; fuzzy text는 금지 |
+| caller/wrong-def 계약 미완성 | Sprint 1 metric 정의 충돌 | tag와 분모 인터페이스만 선행, Sprint 1 baseline을 version ref로 고정 |
+| Sprint 2 manifest 변경 | adapter 중복 구현 | `review-run/v1` JSON Schema contract test와 migration function 제공 |
+| 과거 archive의 절대 경로/개인정보 | 저장소 유출 | PII 검사·마스킹·hash inventory 후 이관 |
+| PR comment 권한/중복 | fork 실패·spam | sticky marker, fork summary fallback, 최소 permissions |
+| 비용과 secret | live eval 오용 | PR에서 secret/네트워크 0, judge는 manual/nightly budget cap |
+
+## 8. 마스터 플랜 v1.1 — Sprint 0c 통합 체크리스트
+
+### 설계/정리
+
+- [ ] `llm_eval/`을 deprecated로 표시하고 DeepEval 의존·import·문서를 제거한다.
+- [ ] 이 문서를 마스터 플랜 v1.1 Sprint 0c 기준 문서로 링크한다.
+- [ ] eval-agent 137개 실파일과 “142개” 보고 차이를 migration record에 남긴다.
+- [ ] 보존/포팅/폐기 목록을 ADR로 승인한다.
+
+### ReviewRun 계약 (Sprint 2 선행)
+
+- [ ] `review-run/v1` Pydantic 모델과 JSON Schema를 확정한다.
+- [ ] diff/model/prompt/skill/context/tool/budget/findings 필드를 contract test로 고정한다.
+- [ ] `ReviewLogManager` → `ReviewRun` adapter와 `RunRecorder` protocol을 만든다.
+- [ ] normal, cache, proactive/fallback multiturn의 manifest coverage를 확인한다.
+
+### Deterministic eval
+
+- [ ] `golden/v1`과 fixture validator를 구현한다.
+- [ ] finding normalize 및 stable one-to-one matcher를 구현한다.
+- [ ] precision/recall/FPR/severity의 0분모·N/A 정책을 테스트한다.
+- [ ] Sprint 1 caller recall/wrong-def tag 및 baseline 입력 계약을 연결한다.
+- [ ] 같은 입력의 report가 byte-identical인지 검증한다.
+
+### Corpus/역사 자산
+
+- [ ] commit size/quota 설정과 경계 테스트를 포팅한다.
+- [ ] 11개 기존 dataset과 3개 sample log를 사람이 재라벨링한다.
+- [ ] 최소 20개 golden case와 clean negative를 stack/크기별로 구성한다.
+- [ ] historical archive를 PII 마스킹·SHA-256 inventory 후 비평가용으로 보존한다.
+
+### CI/운영
+
+- [ ] PR replay workflow, artifact, job summary, sticky comment를 구축한다.
+- [ ] fork PR 및 최소 permission 동작을 검증한다.
+- [ ] fixture 변경 CODEOWNERS/2인 승인 규칙을 적용한다.
+- [ ] live LLM 및 judge를 non-blocking scheduled/manual workflow로 격리한다.
+- [ ] metric threshold, baseline 갱신 절차, rollback 기준을 운영 문서화한다.

--- a/docs/superpowers/specs/2026-07-17-selvage-master-plan.md
+++ b/docs/superpowers/specs/2026-07-17-selvage-master-plan.md
@@ -1,0 +1,599 @@
+# Selvage Master Plan — Agent-Native Verified Review Engine
+
+> 기준일: 2026-07-17 · 작성자: Claude Code (brainstorming session with @anomie7) · 상태: draft v1.3 (Plugin 우선 정책 + 2026-07 모델 업데이트)
+
+## 0. Executive Summary
+
+Selvage는 2026년 2월 `tasks/02-agent-native-review-mode.md`에서 **Agent-Delegated Review**(`get_review_context`, API 키 불필요 MCP 도구)라는 정확한 피벗을 잡았고, 이를 실제로 구현했습니다. 이 방향은 시장 흐름(gstack 4개월 122k stars, Claude Code 138k, Codex 98k)과 정확히 일치합니다. **방향이 틀린 게 아니라 5개월간 실행이 멈췄을 뿐입니다.**
+
+이 마스터 플랜은 4개 Sprint(12–16주)로 방치 부채를 청산하면서 agent-native 방향을 가속합니다. 각 Sprint는 (a) 객관적 종료 metric, (b) 전용 브랜치/워크트리, (c) `claude -p` 독립 검증자 체크리스트를 갖습니다. 사용자는 각 마일스톤 PR을 리뷰하고 배포를 승인합니다.
+
+---
+
+## 1. 배경과 현재 상태 진단
+
+### 1.1 자산 (유지)
+- Python CLI, Apache-2.0, PyPI v0.4.1
+- 테스트 823개 통과 / 18 스킵
+- 멀티 LLM (15개 모델, 4개 provider) — `models.yml`이 2026년 중반 최신
+- Tree-sitter AST 기반 Smart Context (Python/JS/TS/Java/Kotlin 등)
+- MCP 서버 9개 도구, 특히 `get_review_context`(API 키 불필요, host agent LLM 재활용)
+- 3계층 아키텍처 설계(`tasks/02-agent-native-review-mode.md`): Context Engine / Execution / Post-processing
+
+### 1.2 방치 징후 (청산 대상)
+- 최근 5개월 코드 커밋 0건
+- 외부 PR #26을 85일 방치
+- GitHub Actions/CI 인프라 부재
+- CLAUDE.md(v3) vs 실제 prompt(v4) 불일치
+- README 내 모델 표기 구형/신형 혼재
+- `docs/context-optimization-analysis.md`(2025-07) AST 고도화 설계 미이행
+
+### 1.3 경쟁 우위 (정제 필요)
+CodeRabbit($24/월), Claude Code Review($15–25/PR), Codex(`codex review`), Cursor BugBot에 대비:
+1. **AST-precise context** — tree-sitter로 변경 블록만. full-codebase 대비 토큰 5–10x 절약
+2. **API 키 불필호** — `get_review_context`로 호스트 LLM 재활용. 추가 비용 $0
+3. **Multi-LLM** — 15개 모델 스위칭. 단일 vendor lock-in 회피
+
+**문제**: 이 3가지가 README 첫 화면에 불친절. 사용자가 모름.
+
+### 1.4 시장 트렌드 (방향 일치 확인)
+- Autonomous fixing, spec-driven review, repo graph, multi-agent verification
+- Skill engineering, loop engineering, harness engineering, observability
+- GitHub 모멘텀 = 범용 agent + skills (gstack, opencode, claude-code, codex)
+
+---
+
+## 2. 비전: "Agent-Native Verified Review Engine"
+
+selvage는 "또 하나의 GitHub 코멘트 봇"이 아니라 **"로컬에서 코드를 구조적으로 압축하고, 원하는 LLM이나 코딩 에이전트에 검증 가능한 review context를 공급하는 오픈 품질 레이어"**입니다.
+
+- **Agent-Native**: host agent(Claude Code, Cursor, Codex)의 LLM을 재활용
+- **Verified**: finding마다 AST path, caller chain, test 결과를 증거로
+- **Engine**: 재현 가능한 ReviewRun manifest + OTel trace로 eval/디버깅 기반
+
+---
+
+## 3. 마스터 플랜 — 4개 Sprint
+
+### 3.0 실행 모델 (AI 병렬 디스패치 기반)
+
+인간 기준 "1–2주"는 orca + codex/claude 병렬 디스패치 시대에 안 맞습니다. 대신 아래 모델을 사용합니다.
+
+- **작업 단위 (task)**: 에이전트 1회 실행으로 끝낼 수 있는 분량
+- **병렬 디스패치 그룹**: 서로 독립적인 task들을 묶어 여러 에이전트가 병렬 처리
+- **검증 사이클**: 그룹 종료 시 `claude -p` 독립 검증자가 체크리스트 평가
+- **승인 사이클**: 사용자가 PR을 리뷰하고 머지 승인 (실제 병목)
+
+**wall-clock = (직렬 그룹 수 × 에이전트 실행 시간) + 사용자 승인 대기**
+
+- codex 1회 실행: 보통 1–3시간 (웹 검색 + 코드 작성 + 테스트)
+- claude -p 1회 실행: 수분–30분 (체크리스트 검증)
+- 사용자 승인: 가변 (몇 시간~하루)
+
+Sprint는 인간 기간이 아니라 **디스패치 사이클 수**로 표현합니다.
+
+### 3.0.1 Sprint 요약
+
+| Sprint | 디스패치 모델 | 병렬 그룹 수 | 직렬 깊이 | wall-clock 추정 (사용자 대기 제외) |
+|---|---|---|---|---|
+| **0a. CI/CD 인프라** | codex 1대 + claude -p 검증 | 1 | 1 | 3–6시간 |
+| **0b. 문서/마켓플레이스** | codex 1대 + claude -p 검증 | 1 (0a와 병렬) | 1 | 2–4시간 |
+| **1. AST V2** | codex 2대 병렬 (model + extractor) + claude -p 검증 | 2 | 2 | 1–2일 |
+| **2. Verified Review** | codex 2–3대 병렬 + claude -p 검증 | 3 | 3 | 2–4일 |
+| **3. Distribution** | codex 2대 병렬 (ast-grep + SARIF) + claude -p 검증 | 2 | 2 | 1–2일 |
+
+### 3.0.2 마스터 플랜 표
+
+| Sprint | 목표 | 종료 metric | 릴리스 |
+|---|---|---|---|
+| **0a. CI/CD 인프라** | GitHub Actions + develop 브랜치 + TestPyPI 자동 배포 | CI green (push/PR), TestPyPI 자동 업로드, e2e Docker 통과 | — (내부 인프라) |
+| **0b. 문서/마켓플레이스** | README/CLAUDE.md 동기화, Claude Plugin Marketplace 등록 | README 차별점 명시, Claude Plugin `/plugin install` 작동 | **v0.4.2** |
+| **0c. Eval 인프라** | 자체 경량 eval (ReviewRun + golden fixture) | review-run/v1 스키마 확정, deterministic matcher, ≥20 golden case, CI eval-regression 동작 | **v0.4.2** (0b와 동반) 또는 **v0.5.0** |
+| **1. AST V2** | cross-file caller chain + ranking | caller recall ≥50%↑, wrong-def <5%, 토큰 15%↓ (Sprint 0c metric로 측정) | **v0.5.0** |
+| **2. Verified Review Engine** | reviewer → verifier 전환 | 80% finding에 evidence, FP 30%↓ (Sprint 0c metric로 측정) | **v0.6.0** |
+| **3. Distribution & Polish** | CI 통합 + 한국어 rule pack | GitHub Action 작동, SARIF 표시 | **v0.7.0** |
+
+**의존성 그래프**:
+```
+0a (CI/CD)   ─┬─→ 1 (AST V2) ─→ 2 (Verified Review) ─→ 3 (Distribution)
+              │        ↑
+0b (문서/마켓) ┘        │
+                        │
+0c (Eval 인프라) ───────┘  (Sprint 1의 metric 측정을 위해 선행)
+```
+
+- Sprint 0a/0b/0c는 서로 **독립적 병렬 진행 가능**
+- Sprint 0c는 Sprint 1의 **metric 측정 기반**이므로 Sprint 1 착수 전 완료 권장 (Phase A–B는 최소한 끝낼 것)
+- Sprint 1→2→3은 직렬 (각각 이전 산출물에 의존)
+- Sprint 2의 `ReviewRun` manifest는 Sprint 0c의 `review-run/v1` 스키마와 동일 — Sprint 0c에서 먼저 정의하고 Sprint 2에서 활용
+
+### 3.1 Sprint 0 — Reactivation (0a + 0b 병렬)
+
+Sprint 0는 두 sub-track으로 분리합니다. 0a는 Sprint 1의 필수 선행, 0b는 0a 및 Sprint 1과 병렬 진행.
+
+#### 3.1.1 Sprint 0a — CI/CD 인프라
+
+**목표**: 영속적인 CI/CD 파이프라인 구축. 이후 모든 Sprint의 기반.
+
+**작업**:
+- `develop` 브랜치 생성 — main의 stable mirror, Sprint 통합 지점
+- GitHub Actions 워크플로우 2종:
+  - `.github/workflows/ci.yml` — pytest + ruff + build (feature 브랜치 PR 게이트)
+  - `.github/workflows/release.yml` — TestPyPI(develop push) / PyPI(main push) 자동 배포
+- TestPyPI 자동 배포 파이프라인 — `scripts/build_testpypi_image.sh`를 Actions에서 호출, `selvage-testpypi:latest` Docker 이미지 빌드 + `e2e/` 통합 테스트 실행
+- `feature/*` 브랜치 정책 — Sprint 작업은 feature 브랜치에서, develop로 PR
+- CHANGELOG 자동화 — commitizen 도입 또는 `scripts/update_changelog.py`
+- `pytest tests/` 전체 통과 확인, flaky 테스트 안정화
+
+**종료 조건**:
+- [ ] `develop` 브랜치 존재, main과 동기화된 상태
+- [ ] `.github/workflows/ci.yml`이 feature PR에서 동작 (pytest/ruff/build)
+- [ ] `.github/workflows/release.yml`이 develop push에서 TestPyPI 업로드
+- [ ] TestPyPI 업로드 후 Docker `selvage-testpypi:latest` 빌드 + `e2e/` 통과
+- [ ] main merge 시 PyPI + tag + GitHub Release 자동화
+- [ ] `pytest tests/` 0 failure
+
+**배포**: 내부 인프라 (별도 릴리스 없음)
+
+#### 3.1.2 Sprint 0b — 문서/마켓플레이스
+
+**목표**: 외부 소통 부채 청산, "API 키 불필요 / AST-precise / multi-LLM" 3대 차별점 명확화.
+
+**작업**:
+- README.md / README_KR.md rewrite — 첫 100줄에 3대 차별점 명시, 비교 표 추가
+- CLAUDE.md 동기화 — prompt v3 → v4, models.yml과 일치, README 모델 표기 통일
+- **Claude Code Plugin Marketplace 등록** — `plugin/.claude-plugin/plugin.json` 검증, `/plugin install selvage` 동작 확인, 마켓플레이스 PR(필요시)
+- glama.json / smithery.yaml 재검증 (이미 등록됨, 버전 동기화만)
+- REVIEWING.md 추가 — 외부 기여자 PR 리뷰 프로세스 (반응 시간 SLA 등)
+- Issue/PR 템플릿 — `.github/ISSUE_TEMPLATE/bug.yml`, `feature.yml`, `.github/PULL_REQUEST_TEMPLATE.md`
+- CHANGELOG.md v0.4.2 항목 추가
+
+**종료 조건**:
+- [ ] README 첫 100줄에 3대 차별점 명시 (grep으로 검증 가능한 키워드)
+- [ ] README_KR.md 동일 구조
+- [ ] CLAUDE.md prompt 버전 v4 표시
+- [ ] README 내 모델 표기가 models.yml과 일치
+- [ ] Claude Code Plugin Marketplace에서 `/plugin install` 동작 (실제 설치 테스트)
+- [ ] glama.ai / smithery.ai에서 현재 버전 표시
+- [ ] REVIEWING.md 존재
+- [ ] Issue/PR 템플릿 존재
+- [ ] CHANGELOG v0.4.2 갱신
+
+**배포**: v0.4.2 — PyPI + GitHub Release + Claude Plugin Marketplace. "다시 살아났다" 시그널.
+
+### 3.2 Sprint 1 — AST V2 (2–3주)
+
+**목표**: codex AST 리서치 TOP 5의 1, 2, 3번 통합으로 cross-file caller chain + ranking 구축.
+
+**작업**:
+- `Symbol`, `Reference`, `Edge`, `Provenance` Pydantic 데이터 모델 — `selvage/src/diff_parser/symbol_index/`
+- tree-sitter `tags.scm` 기반 Symbol/Reference extractor (Python/JS/TS 우선)
+- SQLite incremental cache (content-hash 기반 invalidate)
+- import-aware resolver, 1-hop reverse caller chain
+- Aider식 changed-symbol personalization + token-budget ranking
+- `SMART_CONTEXT_V2` feature flag (env `SELVAGE_CONTEXT_VERSION=v2`)
+- 평가 fixture 10–20개 (Python/JS/TS 각 언어별) — `tests/fixtures/symbol_index/`
+- 평가 metric 측정 스크립트 — `scripts/eval_context_v2.py`
+
+**종료 조건**:
+- [ ] Symbol/Reference/Edge/Provenance 모델 정의
+- [ ] tags.scm extractor가 Python/JS/TS에서 동작
+- [ ] SQLite cache가 content-hash로 invalidate
+- [ ] 1-hop caller chain이 fixture에서 정확 추출
+- [ ] SMART_CONTEXT_V2 feature flag로 on/off
+- [ ] metric: 기존 SMART_CONTEXT 대비 caller recall ≥50%↑, wrong-def <5%, 토큰 15%↓
+- [ ] flag off 시 기존 동작 100% 보존 (회귀 테스트 통과)
+
+**배포**: v0.5.0 PyPI + MCP 마켓 갱신
+
+### 3.3 Sprint 2 — Verified Review Engine (4–6주)
+
+**목표**: reviewer → verifier 전환. finding마다 AST path, caller chain, test 결과를 증거로.
+
+**작업**:
+- `ReviewRun` manifest — diff snapshot, base/head SHA, model/prompt/skill versions, context chunks, tool calls, budgets, findings를 불변 JSON으로 저장 — `selvage/src/review/run_manifest.py`
+- Finding verification loop — 1차 reviewer가 finding 후보 → verifier가 AST V2 caller chain + 선택적 테스트 실행으로 반증/확인 → `supported`/`uncertain`/`rejected` + evidence line
+- Finding provenance API — model + AST path + verifier 결과 + 근거 라인을 finding에 첨부
+- OTel-native review trace — root `review.run` span 아래 `git.diff`, `ast.context`, `llm.call`, `tool.verify`, `finding.merge` span. OTLP endpoint 있을 때만 export (opt-in)
+- `verify_finding` MCP 도구 추가 (옵션, 기존 `get_review_context`와 병행)
+- CLI 출력 개선 — finding마다 evidence drill-down 지원 (rich tree)
+- JSON 출력 스키마 확장 — `evidence` 필드 추가
+
+**종료 조건**:
+- [ ] ReviewRun manifest에 모든 실행 증거 기록
+- [ ] verifier가 AST V2 caller chain을 활용해 반증/확인
+- [ ] finding provenance에 AST path/evidence 포함
+- [ ] OTel trace가 review.run root + spans로 구성 (opt-in)
+- [ ] `verify_finding` MCP 도구 동작
+- [ ] CLI에서 finding evidence drill-down 가능
+- [ ] false positive 30%↓ (평가 fixture 기반)
+
+**배포**: v0.6.0 PyPI + MCP 마켓 갱신
+
+### 3.4 Sprint 3 — Distribution & Polish (2–3주)
+
+**목표**: AST V2 + Verified Review를 세상에 내놓기. CI 통합, 한국어/보안 rule pack.
+
+**작업**:
+- ast-grep optional deterministic rule adapter — `selvage[security]` extra, `ast-grep scan --json` subprocess + JSON 경계, Apache-2.0 호환 rule 5–10개 (보안/SQL/shell injection)
+- SARIF 출력 — `selvage review --format sarif > review.sarif`
+- `.selvage.yml` 프로젝트 설정 — model, language, ignore, focus, rules
+- `selvage-lab/selvage-action` GitHub Actions 워크플로우 — PR 트리거 자동 리뷰
+- 한국어 rule pack 시드 — OWASP, 전자금융감독규정, 개인정보처리 (bilingual)
+
+**종료 조건**:
+- [ ] ast-grep adapter가 보안 패턴 deterministic 탐지
+- [ ] SARIF가 GitHub Security 탭에 표시
+- [ ] `.selvage.yml` 파싱/적용 동작
+- [ ] selvage-action이 PR에서 자동 리뷰
+- [ ] 한국어 rule pack 5개 이상
+- [ ] v0.7.0 PyPI 업로드 성공
+
+**배포**: v0.7.0 PyPI + GitHub Marketplace (Actions)
+
+### 3.5 장기 (v0.8+, 마스터 플랜 이후)
+
+- ast-grep 한국어/한국 규정 rule pack 확장
+- SCIP index adapter (optional, precise resolution)
+- auto-fix (`selvage review --apply`)
+- 증분 리뷰 (`selvage review --since-last-review`)
+- VS Code 확장
+
+---
+
+## 4. 마일스톤 / 릴리스 체계
+
+| 버전 | Sprint | 핵심 가치 | 배포 채널 | 추정 wall-clock (사용자 대기 제외) |
+|---|---|---|---|---|
+| (내부) | 0a | CI/CD 인프라 — TestPyPI + develop 브랜치 | — | 3–6시간 |
+| **v0.4.2** | 0b | "다시 살아났다" — 문서/마켓/Claude Plugin | PyPI, GitHub Release, Claude Plugin Marketplace | 2–4시간 (0a와 병렬) |
+| **v0.5.0** | 1 | AST V2 — cross-file caller chain | PyPI, glama, smithery, Claude Plugin Marketplace | 1–2일 |
+| **v0.6.0** | 2 | Verified Review — finding에 증거 | PyPI, MCP 마켓 | 2–4일 |
+| **v0.7.0** | 3 | CI 통합 — GitHub Action + SARIF | PyPI, GitHub Marketplace (Actions) | 1–2일 |
+
+**총 wall-clock 추정**: 5–9일 (순수 작업) + 사용자 승인 대기. 기존 "12–16주" 인간 기준 → AI 병렬 기준으로 **약 10–20%로 압축**.
+
+각 릴리스마다:
+1. CHANGELOG.md 갱신
+2. `__version__.py` 버전업
+3. git tag `vX.Y.Z`
+4. GitHub Actions 자동 빌드 → PyPI 업로드
+5. GitHub Release 노트 자동 생성
+6. MCP 마켓플레이스 server.json 버전 갱신
+
+---
+
+## 5. 브랜치 / 워크트리 전략
+
+### 5.1 orca 워크트리 계층
+
+```
+selvage/main (사용자 검수/배포, 브랜치: main)
+└── master-plan-2026-07-17/ (작업 허브, 브랜치: anomie7/master-plan-2026-07-17)
+    ├── docs/superpowers/specs/2026-07-17-selvage-master-plan.md (이 문서)
+    ├── docs/superpowers/plans/ (각 Sprint 구현 계획)
+    ├── docs/research/external/ (codex 리서치 결과)
+    ├── sprint-0-reactivation/ (Sprint 0 실행)
+    │   브랜치: release/v0.4.2
+    ├── sprint-1-ast-v2/ (Sprint 1 실행)
+    │   브랜치: release/v0.5.0
+    ├── sprint-2-verified-review/ (Sprint 2 실행)
+    │   브랜치: release/v0.6.0
+    └── sprint-3-distribution/ (Sprint 3 실행)
+        브랜치: release/v0.7.0
+```
+
+### 5.2 브랜치 정책 (main + develop + feature/*)
+
+```
+main      ──── 사용자가 직접 관리, 배포 브랜치 ──── tag vX.Y.Z → PyPI + GitHub Release
+            │
+develop   ──── Sprint 통합 지점, stable mirror of main + 진행 중 Sprint 병합
+            │  push → TestPyPI 자동 배포 + Docker 통합 테스트
+            │
+feature/* ──── 개별 task 작업 브랜치 (예: feature/sprint-0a-ci-yaml)
+               PR → develop (CI 게이트: pytest + ruff + build)
+```
+
+- `main`: 사용자만 머지. 릴리스 브랜치.
+- `develop`: Sprint의 feature들이 모이는 통합 브랜치. Sprint 종료 시 main으로 PR.
+- `feature/*`: 에이전트가 디스패치되는 실제 작업 브랜치. 1 task = 1 feature 원칙.
+- `anomie7/master-plan-2026-07-17`: 디자인/계획 문서만 보관. 코드 변경 없음.
+
+**Sprint 브랜치 네이밍**:
+- Sprint 0a: `feature/sprint-0a-ci-cd-*` (여러 feature로 쪼갬)
+- Sprint 0b: `feature/sprint-0b-docs-*`, `feature/sprint-0b-claude-plugin`
+- Sprint 1: `feature/sprint-1-symbol-model`, `feature/sprint-1-tags-extractor`, ...
+- 각 Sprint의 feature들이 develop로 PR → Sprint 전체 완료 시 main으로 cherry-pick 또는 squash merge
+
+### 5.2.1 TestPyCI/CD 파이프라인 상세
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ feature/sprint-N-* 브랜치에서 PR 생성                            │
+└─────────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+        ┌──────────────────────────────────────┐
+        │ .github/workflows/ci.yml             │
+        │  - pytest tests/                     │
+        │  - ruff check .                      │
+        │  - python -m build (검증 only)       │
+        │  - coverage 보고                     │
+        └──────────────────────────────────────┘
+                            │ PR 승인 (사용자)
+                            ▼
+        ┌──────────────────────────────────────┐
+        │ develop 브랜치로 merge               │
+        │  → .github/workflows/release.yml     │
+        │    1) python -m build                │
+        │    2) twine upload --repository testpypi │
+        │    3) scripts/build_testpypi_image.sh │
+        │    4) docker run selvage-testpypi:latest pytest e2e/ │
+        └──────────────────────────────────────┘
+                            │ Sprint 종료 시 (사용자 승인)
+                            ▼
+        ┌──────────────────────────────────────┐
+        │ main 브랜치로 merge (PR)             │
+        │  → .github/workflows/release.yml     │
+        │    1) twine upload (PyPI 정식)       │
+        │    2) git tag vX.Y.Z                 │
+        │    3) GitHub Release 자동 생성       │
+        │    4) MCP 마켓 server.json 갱신 PR   │
+        └──────────────────────────────────────┘
+```
+
+기존 자산 활용: `scripts/build_testpypi_image.sh`, `e2e/dockerfiles/testpypi/Dockerfile`, `e2e/` 테스트 스위트.
+
+### 5.3 Sprint 실행 워크플로우
+
+각 Sprint:
+1. master-plan 워크트리에서 `writing-plans` 스킬로 구현 계획 작성 → `docs/superpowers/plans/sprint-N-<topic>.md`
+2. 전용 child 워크트리 생성: `orca worktree create --name sprint-N-<topic> --parent-worktree name:master-plan-2026-07-17 --agent <codex|claude>`
+3. 워크트리에서 `release/vX.Y.Z` 브랜치로 작업
+4. 독립 검증자(`claude -p`) 체크리스트 실행 (§6)
+5. 사용자 PR 리뷰
+6. Merge to main → tag → PyPI 배포
+7. Sprint 워크트리 정리
+
+---
+
+## 6. 독립 검증자 (claude -p) 체크리스트
+
+각 Sprint 종료 시, **main 작업 세션과 다른 독립 컨텍스트**를 가진 Claude가 체크리스트 기반 검증을 수행.
+
+### 6.1 실행 방식
+
+옵션 A (orca 기반):
+```bash
+orca worktree create --name verify-sprint-N --parent-worktree name:sprint-N-<topic> --agent claude \
+  --prompt "$(cat docs/superpowers/specs/sprint-N-verification-checklist.md)"
+```
+
+옵션 B (직접):
+```bash
+cd /Users/demin_coder/orca/workspaces/selvage/sprint-N-<topic>
+claude -p "$(cat ../master-plan-2026-07-17/docs/superpowers/specs/sprint-N-verification-checklist.md)"
+```
+
+검증자는 체크리스트의 각 항목을 객관적으로 평가하고, FAIL 항목이 있으면 수정 권고안과 함께 보고.
+
+### 6.2 Sprint별 체크리스트
+
+#### Sprint 0a 체크리스트 (CI/CD 인프라)
+
+```markdown
+# Sprint 0a CI/CD 인프라 검증
+
+아래 항목을 하나씩 객관적으로 검증하라. 각 항목에 PASS/FAIL과 증거(파일 경로, 명령어 출력 등)를 붙일 것.
+
+## 브랜치 구조
+1. develop 브랜치가 존재하고 main과 동기화돼 있는가? (git branch -a 출력)
+2. feature/* 브랜치 정책이 문서화됐는가? (CONTRIBUTING.md 또는 REVIEWING.md)
+
+## CI 워크플로우
+3. .github/workflows/ci.yml이 존재하는가?
+4. ci.yml이 feature 브랜치 PR에서 pytest를 실행하는가? (workflow run 증거)
+5. ci.yml이 ruff check를 실행하는가?
+6. ci.yml이 python -m build를 실행하는가?
+7. coverage 보고가 있는가?
+
+## Release 워크플로우
+8. .github/workflows/release.yml이 존재하는가?
+9. develop 브랜치 push 시 TestPyPI로 자동 업로드되는가? (Actions 로그 증거)
+10. scripts/build_testpypi_image.sh가 Actions에서 호출되는가?
+11. selvage-testpypi:latest Docker 이미지가 빌드되는가?
+12. e2e/ 통합 테스트가 Docker 안에서 실행되는가?
+13. main 브랜치 merge 시 PyPI 정식 업로드 + tag + GitHub Release가 자동화됐는가?
+
+## 품질 게이트
+14. pytest tests/ 가 0 failure로 통과하는가? (stdout 마지막 20줄)
+
+최종 판정: 14/14 PASS면 Sprint 0a 종료 승인. FAIL 항목은 수정 권고안 작성.
+```
+
+#### Sprint 0b 체크리스트 (문서/마켓플레이스)
+
+```markdown
+# Sprint 0b 문서/마켓플레이스 검증
+
+## README/CLAUDE.md 동기화
+1. README.md 첫 100줄에 "API 키 불필요" 키워드가 명시됐는가? (head -100 README.md | grep)
+2. README.md 첫 100줄에 "AST" 또는 "tree-sitter"가 명시됐는가?
+3. README.md 첫 100줄에 "multi-LLM" 또는 "OpenRouter"가 명시됐는가?
+4. README_KR.md도 동일한 차별점 구조인가?
+5. CLAUDE.md의 prompt 버전이 v4로 표시되는가? (grep 결과)
+6. README 내 모델 표기가 models.yml과 일치하는가?
+
+## Claude Code Plugin Marketplace
+7. plugin/.claude-plugin/plugin.json이 Claude plugin marketplace 스키마를 만족하는가?
+8. plugin/agents/selvage-reviewer.md와 plugin/skills/review/SKILL.md가 유효한가?
+9. Claude Code에서 `/plugin install selvage`가 동작하는가? (실제 설치 로그)
+10. 마켓플레이스 등록 PR이 제출됐거나 승인됐는가? (URL)
+
+## 기존 마켓 갱신
+11. glama.json이 valid하고 현재 버전을 반영하는가?
+12. smithery.yaml이 valid하고 현재 버전을 반영하는가?
+
+## 프로세스 문서
+13. REVIEWING.md가 존재하고 외부 기여자 PR 리뷰 프로세스(반응 시간 SLA 등)를 설명하는가?
+14. .github/ISSUE_TEMPLATE/bug.yml, feature.yml이 존재하는가?
+15. .github/PULL_REQUEST_TEMPLATE.md가 존재하는가?
+16. CHANGELOG.md가 v0.4.2 항목으로 갱신됐는가?
+
+최종 판정: 16/16 PASS면 Sprint 0b 종료 승인. v0.4.2 릴리스 가능.
+```
+
+#### Sprint 1 체크리스트 (요약)
+
+- AST V2 데이터 모델 정의 (Symbol/Reference/Edge/Provenance)
+- Python/JS/TS tags.scm extractor 동작
+- SQLite cache content-hash invalidate
+- 1-hop caller chain 추출 정확도 (fixture 기반)
+- SMART_CONTEXT_V2 feature flag on/off
+- metric 달성: caller recall ≥50%↑, wrong-def <5%, 토큰 15%↓
+- flag off 시 기존 동작 보존 (회귀 테스트 통과)
+- AST V2 평가 보고서 docs/research/internal/sprint-1-ast-v2-eval.md 작성
+
+#### Sprint 2 체크리스트 (요약)
+
+- ReviewRun manifest 스키마 정의 + 실행 증거 전부 기록
+- verifier가 AST V2 caller chain 활용
+- finding provenance에 AST path/evidence 포함
+- OTel trace (review.run root + spans) opt-in 동작
+- `verify_finding` MCP 도구 동작
+- CLI evidence drill-down 동작
+- false positive 30%↓ (평가 fixture)
+
+#### Sprint 3 체크리스트 (요약)
+
+- ast-grep adapter 보안 패턴 deterministic 탐지
+- SARIF 출력 valid + GitHub Security 탭 표시
+- `.selvage.yml` 파싱/적용 동작
+- selvage-action PR 자동 리뷰 동작
+- 한국어 rule pack 5개 이상
+- v0.7.0 PyPI 업로드 성공
+
+### 6.3 검증자 산출물 형식
+
+```markdown
+# Sprint N 검증 보고 (YYYY-MM-DD)
+
+검증자: claude -p (독립 컨텍스트)
+검증 대상: release/vX.Y.Z-<topic> 브랜치 HEAD <sha>
+
+## 결과 요약
+- PASS: X/Y
+- FAIL: Z (항목 번호)
+
+## 항목별 평가
+1. [PASS] ... 증거: ...
+2. [FAIL] ... 이유: ... 수정 권고: ...
+
+## 종합 판정
+- [ ] Sprint 종료 승인 (모든 항목 PASS)
+- [ ] 수정 후 재검증 필요 (FAIL 항목 존재)
+
+## 권고사항
+...
+```
+
+---
+
+## 7. 배포 파이프라인
+
+각 v0.X.Y 릴리스:
+
+1. Sprint 워크트리에서 코드 완성 + 테스트 통과
+2. 독립 검증자 체크리스트 PASS
+3. PR to main (Sprint 브랜치 → main)
+4. 사용자 리뷰 + 승인
+5. Merge to main (squash or merge commit)
+6. `git tag vX.Y.Z` + `git push --tags`
+7. GitHub Actions 자동 빌드 (`python -m build`)
+8. PyPI 업로드 (twine, `SELVAGE_PYPI_TOKEN` secret)
+9. GitHub Release 노트 자동 생성 (CHANGELOG 기반)
+10. MCP 마켓플레이스 server.json 버전 갱신 (별도 PR 또는 자동)
+
+---
+
+## 8. 리스크와 완화
+
+| 리스크 | 확률 | 영향 | 완화 |
+|---|---|---|---|
+| 1인 메인테이너 번아웃 | 높음 | 높음 | Sprint 4–6주 제한, 명확한 종료 metric, 부채 청산 우선 |
+| AST V2 언어별 파편화 | 중간 | 중간 | Python/JS/TS 우선, Java/Kotlin은 Sprint 4+(v0.8+)로 |
+| OTel 의존성 무거움 | 낮음 | 중간 | opt-in, OTLP endpoint 있을 때만 export |
+| ast-grep Rust 바인딩 복잡도 | 중간 | 중간 | subprocess + JSON 경계로 격리, `ast-grep-cli` pip wheel 사용 |
+| 독립 검증자 품질 편차 | 중간 | 중간 | 체크리스트 고정, deterministic exit, 증거 요구 |
+| 시장 변화 (Claude/Codex 리뷰 고도화) | 높음 | 높음 | Agent-Delegated Review로 호스트 agent에 종속 (역이용) |
+| MCP 프로토콜 변경 | 낮음 | 높음 | FastMCP 업데이트 추적, 스키마 버전 고정 |
+
+---
+
+## 9. 성공 지표
+
+### 3개월 후 (Sprint 1 완료 시)
+- PyPI 월간 다운로드: baseline 대비 2x (목표 ~500)
+- GitHub stars: +50
+- MCP 마켓플레이스(glama + smithery) 설치: 100+
+
+### 6개월 후 (Sprint 3 완료 시)
+- PyPI 월간 다운로드: 5x (목표 2,500+)
+- GitHub stars: 500+ (현재 baseline에서 +400)
+- selvage-action GitHub Marketplace 설치: 50+
+- 한국 개발자 커뮤니티(블로그/X/Slack) 언급: 10+
+
+### 12개월 후 (장기 비전)
+- 한국 코드 리뷰 도구 1위 OSS
+- "AST-precise context + Agent-Delegated Review"가 selvage의 정체성으로 정착
+- v1.0.0 (Spec-driven review, auto-fix 포함)
+
+---
+
+## 10. 의사결정 기록 (ADR-style)
+
+- **ADR-001**: Sprint 간은 직렬이 원칙이되, 독립적인 sub-track은 병렬 디스패치한다. 특히 Sprint 0b(문서/마켓)는 Sprint 0a(CI/CD) 및 Sprint 1과 병렬 진행. 단, 코드 의존성이 있는 Sprint(1→2→3)은 직렬.
+- **ADR-002**: AST V2는 feature flag로 도입 (`SELVAGE_CONTEXT_VERSION=v2`). 이유: 기존 사용자 회귀 방지, A/B 평가 가능.
+- **ADR-003**: 독립 검증자는 `claude -p` 또는 orca 워크트리 claude로 실행. 이유: main 세션과 컨텍스트 격리로 객관성 확보.
+- **ADR-004**: ast-grep은 Rust 바인딩 직접 구현 대신 subprocess + JSON. 이유: Python CLI 단순성 유지, Rust 격리.
+- **ADR-005**: OTel은 opt-in. 이유: zero-data-retention 조직 사용자 보호, 기본 의존성 최소.
+- **ADR-006**: `.selvage.yml`은 Sprint 3에서 도입 (Sprint 0이 아님). 이유: AST V2/Verified Review와 결합해야 가치 있음.
+- **ADR-007 (eval 위치/라이센스)**: eval 인프라 로직(`selvage/src/eval/`)은 selvage 리포 안에 구축. fixture는 두 종류 — (a) **synthetic**: selvage 팀이 직접 작성한 inline 패치 (Apache 2.0 저작물), (b) **external**: 외부 OSS repo의 diff를 runtime에 clone하여 추출, **코드 자체는 저장하지 않음** (메타데이터 `repo_url + commit_sha + diff_range + license_attribution`만 보관). 이유: 공개 repo에 타 OSS 코드를 포함하는 것은 라이센스/저작권 리스크 (GPL 전염, attribution 부담). 코드를 복제하지 않으면 리스크 0. external fixture는 permissive 라이센스(MIT/Apache/BSD/ISC/MPL)만 허용, GPL/상용 금지.
+- **ADR-008 (CLI vs Plugin 정책 — Plugin 우선, CLI 현행 유지)**: 새 기능(AST V2, Verified Review, rule pack 등)은 **Plugin/MCP에 먼저** 구현하고 CLI는 그 다음. 단, **CLI는 경량화하지 않고 현행 구조 유지** (사용자 결정, 2026-07-19). 이유: (a) 시장 트렌트가 agent+plugin로 이동 중 (codex market-landscape: gstack 122k, opencode 186k, claude-code 138k)이므로 Plugin 우선이 합리적. (b) 단, CI/자동화(Sprint 3 GitHub Action, SARIF)는 agent 없이 돌아가야 하므로 CLI가 여전히 필요 — 경량화하면 CI 통합이 복잡해짐. (c) 1인 메인테이너 부담을 고려할 때, CLI 구조 변경(모듈 분리 등)은 가치 대비 비용이 큼. 그래서 CLI는 현행 유지하되 새 기능의 70%는 Plugin/MCP 우선으로.
+
+---
+
+## 11. 참고 자료
+
+### 리서치 결과 (codex)
+- `docs/research/external/2026-07-17-market-landscape.md` — 시장/경쟁사 분석
+- `docs/research/external/2026-07-17-engineering-concepts.md` — Skill/Loop/Harness/Eval/Spec
+- `docs/research/external/2026-07-17-ast-context-research.md` — AST 고도화 OSS 리서치 (TOP 5 우선순위)
+
+### 기존 설계 (selvage 내부)
+- `docs/product_analysis_and_roadmap.md` — 2026-01 원본 로드맵
+- `tasks/02-agent-native-review-mode.md` — Agent-Delegated Review 설계
+- `docs/agent-delegated-review-spec.md` — 위 스펙 상세 (45KB)
+- `docs/context-optimization-analysis.md` — 2025-07 AST 고도화 원본 설계
+
+### 외부 링크
+- [Anthropic Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [Aider repo map](https://aider.chat/2023/10/22/repomap.html)
+- [ast-grep](https://ast-grep.github.io/)
+- [SCIP](https://github.com/sourcegraph/scip)
+- [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)
+
+---
+
+## 12. 다음 단계
+
+1. 사용자가 이 마스터 플랜을 리뷰하고 승인
+2. `writing-plans` 스킬로 Sprint 0 세부 구현 계획 작성 → `docs/superpowers/plans/sprint-0-reactivation.md`
+3. Sprint 0 전용 워크트리 생성 (`orca worktree create --name sprint-0-reactivation --parent-worktree name:master-plan-2026-07-17`)
+4. Sprint 0 실행 → 검증 → PR → v0.4.2 배포
+5. Sprint 1–3 반복
+
+---
+
+*문서 버전: 1.0 · 최종 갱신: 2026-07-17 · 작성자: Claude Code (brainstorming session)*


### PR DESCRIPTION
## Summary
selvage 재활성화를 위한 마스터 플랜과 Sprint 구현 계획, 그리고 방향 결정을 뒷받침한 리서치 결과를 main에 보존합니다.

## 포함 산출물
- **specs/2026-07-17-selvage-master-plan.md** (v1.3) — 4-Sprint 마스터 플랜, ADR 8개
- **plans/2026-07-17-sprint-0a-ci-cd.md** — Sprint 0a (CI/CD 인프라) 7-task TDD 계획
- **plans/sprint-0c-eval-infra.md** — Sprint 0c (자체 경량 eval) Phase A-E
- **research/external/** — 시장 분석, 엔지니어링 개념, AST OSS 비교, selvage vs OSS 비교 (총 87KB)

## 의사결정 기록 (ADR)
- ADR-001: Sprint 간 직렬, sub-track은 병렬
- ADR-002: AST V2는 feature flag
- ADR-003: 독립 검증자는 claude -p / orca
- ADR-004: ast-grep은 subprocess + JSON
- ADR-005: OTel은 opt-in
- ADR-006: .selvage.yml은 Sprint 3에서
- ADR-007: eval은 synthetic + external runtime-clone (라이센스 회피)
- ADR-008: Plugin 우선, CLI는 현행 유지

## Test plan
- [ ] 문서 렌더링 GitHub에서 정상
- [ ] 링크/경로 정확
- [ ] ADR 번호 중복 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)